### PR TITLE
fix(tv-next): change the syntax of media query when using css module

### DIFF
--- a/packages/mirror-tv-next/components/layout/header/header-top.module.css
+++ b/packages/mirror-tv-next/components/layout/header/header-top.module.css
@@ -5,15 +5,19 @@
   display: flex;
   align-items: center;
   justify-content: center;
+}
 
-  @media (min-width: 768px) {
+@media (min-width: 768px) {
+  .wrapper {
     background: #fff;
     height: 64px;
     padding: 0 16px;
     justify-content: space-between;
   }
+}
 
-  @media (min-width: 1200px) {
+@media (min-width: 1200px) {
+  .wrapper {
     height: 73px;
     padding: 0 44px;
   }
@@ -23,8 +27,10 @@
   width: 192px;
   height: 36px;
   display: none;
+}
 
-  @media (min-width: 768px) {
+@media (min-width: 768px) {
+  .logo {
     display: flex;
   }
 }
@@ -35,7 +41,10 @@
   height: 52px;
   align-items: center;
   overflow: hidden;
-  @media (min-width: 768px) {
+}
+
+@media (min-width: 768px) {
+  .sponsorsWrapper {
     gap: 10px;
   }
 }

--- a/packages/mirror-tv-next/components/layout/header/main-header.module.css
+++ b/packages/mirror-tv-next/components/layout/header/main-header.module.css
@@ -4,16 +4,18 @@
 
 .pcHeaderWrapper {
   display: none;
-
-  @media (min-width: 768px) {
-    display: block;
-  }
 }
 
 .mobHeaderWrapper {
   display: block;
+}
 
-  @media (min-width: 768px) {
+@media (min-width: 768px) {
+  .pcHeaderWrapper {
+    display: block;
+  }
+
+  .mobHeaderWrapper {
     display: none;
   }
 }

--- a/packages/mirror-tv-next/components/layout/header/nav-items.module.css
+++ b/packages/mirror-tv-next/components/layout/header/nav-items.module.css
@@ -58,12 +58,16 @@
   height: 44px;
   display: flex;
   align-items: center;
+}
 
-  @media (min-width: 768px) {
+@media (min-width: 768px) {
+  .navWrapper {
     padding: 0 16px;
   }
+}
 
-  @media (min-width: 1200px) {
+@media (min-width: 1200px) {
+  .navWrapper {
     padding: 0 44px;
     font-size: 16px;
   }
@@ -77,8 +81,10 @@
 
   max-width: 560px;
   height: 28px;
+}
 
-  @media (min-width: 1200px) {
+@media (min-width: 1200px) {
+  .visibleItems {
     max-width: 960px;
   }
 }
@@ -92,12 +98,15 @@
   font-size: 14px;
   font-weight: 100;
   line-height: normal;
-
-  @media (min-width: 768px) {
+}
+@media (min-width: 768px) {
+  .restOfCategories {
     padding: 0 16px;
   }
+}
 
-  @media (min-width: 1200px) {
+@media (min-width: 1200px) {
+  .restOfCategories {
     padding: 0 44px;
   }
 }


### PR DESCRIPTION
### Must Know:
在撰寫 CSS-Modules 時，如果把 media query 寫在 class 中，在 Safari 會失效：
❌ 這種寫法不行：

```
.pcHeaderWrapper {
  display: none;

    @media (min-width: 768px) {
      display: block;
    }
}
```

✅ 必須寫成這樣：

```
@media (min-width: 768px) {
    .pcHeaderWrapper {
      display: block;
    }

    .mobHeaderWrapper {
      display: none;
    }
}
```