### PR TITLE
feat(tv-next): server action demo

### DIFF
--- a/packages/mirror-tv-next/app/tag/[name]/page.tsx
+++ b/packages/mirror-tv-next/app/tag/[name]/page.tsx
@@ -1,11 +1,12 @@
-import { getClient } from '~/apollo-client'
 import errors from '@twreporter/errors'
-import { getPostsByTagName, PostByTagName } from '~/graphql/query/posts'
-import { FILTERED_SLUG } from '~/constants/constant'
-import styles from '~/styles/pages/tag-page.module.scss'
+import { getClient } from '~/apollo-client'
 import UiPostCard from '~/components/shared/ui-post-card'
-import { formatePostImage } from '~/utils'
+import UiMoreTagList from '~/components/tag/more-tag-list'
+import { FILTERED_SLUG } from '~/constants/constant'
 import { GLOBAL_CACHE_SETTING } from '~/constants/environment-variables'
+import { getPostsByTagName, PostByTagName } from '~/graphql/query/posts'
+import styles from '~/styles/pages/tag-page.module.scss'
+import { formatePostImage } from '~/utils'
 
 export const revalidate = GLOBAL_CACHE_SETTING
 
@@ -93,6 +94,7 @@ export default async function TagPage({
             })}
           </ol>
         )}
+        <UiMoreTagList tagName={tagName} pageSize={PAGE_SIZE} />
       </div>
     </section>
   )

--- a/packages/mirror-tv-next/components/layout/footer.tsx
+++ b/packages/mirror-tv-next/components/layout/footer.tsx
@@ -32,7 +32,7 @@ const socialLinks = [
   },
   {
     href: HEADER_BOTTOM_LINKS.line,
-    src: 'icons/icon-line-dark.svg',
+    src: '/icons/icon-line-dark.svg',
     alt: 'line icon',
   },
   {
@@ -42,7 +42,7 @@ const socialLinks = [
   },
   {
     href: HEADER_BOTTOM_LINKS.x,
-    src: 'icons/icon-x.svg',
+    src: '/icons/icon-x.svg',
     alt: 'x(former twitter) icon',
   },
 ]

--- a/packages/mirror-tv-next/components/shared/ui-load-more-button.tsx
+++ b/packages/mirror-tv-next/components/shared/ui-load-more-button.tsx
@@ -1,0 +1,13 @@
+// 按鈕UI本身不需要使用 'use client'
+
+type UiLoadMoreButtonProps = {
+  title: string
+  onClick: () => void | Promise<void>
+}
+
+export default function UiLoadMoreButton({
+  title,
+  onClick,
+}: UiLoadMoreButtonProps) {
+  return <button onClick={onClick}>{title}</button>
+}

--- a/packages/mirror-tv-next/components/tag/action.jsx
+++ b/packages/mirror-tv-next/components/tag/action.jsx
@@ -1,0 +1,6 @@
+'use server'
+
+export async function fetchMoreItems(page) {
+  console.log('perform server action here')
+  console.log(page)
+}

--- a/packages/mirror-tv-next/components/tag/action.jsx
+++ b/packages/mirror-tv-next/components/tag/action.jsx
@@ -3,4 +3,6 @@
 export async function fetchMoreItems(page) {
   console.log('perform server action here')
   console.log(page)
+
+  return 'more posts'
 }

--- a/packages/mirror-tv-next/components/tag/more-tag-list.tsx
+++ b/packages/mirror-tv-next/components/tag/more-tag-list.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { useState } from 'react'
+import UiLoadMoreButton from '../shared/ui-load-more-button'
+import { fetchMoreItems } from './action'
+
+type UiMoreTagListProps = {
+  tagName: string
+  pageSize: number
+}
+
+export default function UiMoreTagList({
+  tagName,
+  pageSize,
+}: UiMoreTagListProps) {
+  const [page, setPage] = useState(1)
+
+  return (
+    <section>
+      <UiLoadMoreButton
+        title="看更多"
+        onClick={async () => {
+          setPage((prevPage) => prevPage + 1)
+          await fetchMoreItems(page)
+        }}
+      />
+    </section>
+  )
+}

--- a/packages/mirror-tv-next/components/tag/more-tag-list.tsx
+++ b/packages/mirror-tv-next/components/tag/more-tag-list.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import UiLoadMoreButton from '../shared/ui-load-more-button'
 import { fetchMoreItems } from './action'
 
@@ -15,6 +15,17 @@ export default function UiMoreTagList({
 }: UiMoreTagListProps) {
   const [page, setPage] = useState(1)
 
+  const [posts, setPosts] = useState([])
+
+  useEffect(() => {
+    const updatePosts = async () => {
+      const updatePosts = await fetchMoreItems()
+      setPosts(updatePosts)
+    }
+
+    updatePosts()
+  }, [])
+
   return (
     <section>
       <UiLoadMoreButton
@@ -24,6 +35,7 @@ export default function UiMoreTagList({
           await fetchMoreItems(page)
         }}
       />
+      <p>{posts}</p>
     </section>
   )
 }

--- a/packages/mirror-tv-next/styles/components/shared/ui-post-card.module.scss
+++ b/packages/mirror-tv-next/styles/components/shared/ui-post-card.module.scss
@@ -79,7 +79,7 @@
   position: absolute;
   bottom: 0;
   right: 0;
-  ::before {
+  &::before {
     content: '';
     display: block;
     border-color: transparent transparent transparent white;


### PR DESCRIPTION
這個 pr 主要是 demo `server action` 的用法， 點擊 `more-tag-list.tsx` 中的看更多按鈕之後，會觸發 `fetchMoreItems`這個 server action，可以從 sever side 使用 apollo-client fetch more items。 
```
onClick={async () => {
    setPage((prevPage) => prevPage + 1)
    await fetchMoreItems(page)
    }}
```
另外需要注意的是按鈕UI component 本身不需要使用 `use client` directive，只有會需要用到 hook 的 `more-tag-list.tsx`才需要。