### PR TITLE
feat(tv-next): add Hero section leading type - video and image

### DIFF
--- a/packages/mirror-tv-next/app/topic/[slug]/page.tsx
+++ b/packages/mirror-tv-next/app/topic/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import errors from '@twreporter/errors'
 import { notFound } from 'next/navigation'
 import { getClient } from '~/apollo-client'
+import HeroVideo from '~/components/topic/single-topic/hero-video'
 import { GLOBAL_CACHE_SETTING } from '~/constants/environment-variables'
 import type { SingleTopic } from '~/graphql/query/topic'
 import { fetchPostsByTopicSlug } from '~/graphql/query/topic'
@@ -53,8 +54,14 @@ export default async function SingleTopicPage({
 
   return (
     <main className={styles.mainWrapper}>
-      <section></section>
-      <div>{singleTopic.title}</div>
+      {/* Conditionally render HeroVideo if singleTopic.leading is 'video' */}
+      {singleTopic.leading === 'video' && (
+        <HeroVideo videoSrc={singleTopic.heroVideo.url} />
+      )}
+      <div>
+        {singleTopic.title}
+        {singleTopic.leading}
+      </div>
     </main>
   )
 }

--- a/packages/mirror-tv-next/app/topic/[slug]/page.tsx
+++ b/packages/mirror-tv-next/app/topic/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import errors from '@twreporter/errors'
 import { notFound } from 'next/navigation'
 import { getClient } from '~/apollo-client'
+import HeroImage from '~/components/topic/single-topic/hero-image'
 import HeroVideo from '~/components/topic/single-topic/hero-video'
 import { GLOBAL_CACHE_SETTING } from '~/constants/environment-variables'
 import type { SingleTopic } from '~/graphql/query/topic'
@@ -58,6 +59,7 @@ export default async function SingleTopicPage({
       {singleTopic.leading === 'video' && (
         <HeroVideo videoSrc={singleTopic.heroVideo.url} />
       )}
+      {singleTopic.leading === 'image' && <HeroImage heroImage = {singleTopic.heroImage} alt={singleTopic.title} />}
       <div>
         {singleTopic.title}
         {singleTopic.leading}

--- a/packages/mirror-tv-next/components/shared/article-content-video.tsx
+++ b/packages/mirror-tv-next/components/shared/article-content-video.tsx
@@ -1,0 +1,17 @@
+import styles from '~/styles/components/shared/article-content-video.module.scss'
+
+type ArticleContentVideoProps = {
+  videoSrc: string
+}
+
+export default function ArticleContentVideo({
+  videoSrc,
+}: ArticleContentVideoProps) {
+  return (
+    <div className={styles.videoWrapper}>
+      <video preload="metadata" autoPlay loop playsInline muted>
+        <source src={videoSrc} />
+      </video>
+    </div>
+  )
+}

--- a/packages/mirror-tv-next/components/shared/responsive-image.tsx
+++ b/packages/mirror-tv-next/components/shared/responsive-image.tsx
@@ -1,6 +1,6 @@
 'use client'
-import { PostImage } from '~/utils'
 import Image from '@readr-media/react-image'
+import { PostImage } from '~/utils'
 
 type UiPostCardProps = {
   images: PostImage

--- a/packages/mirror-tv-next/components/shared/youtube-embed.tsx
+++ b/packages/mirror-tv-next/components/shared/youtube-embed.tsx
@@ -1,0 +1,18 @@
+import styles from '~/styles/components/shared/youtube-embed.module.scss'
+
+type YoutubeEmbedProps = {
+  youtubeId: string
+}
+
+export default function YoutubeEmbed({ youtubeId }: YoutubeEmbedProps) {
+  return (
+    <div className={styles.videoWrapper}>
+      <iframe
+        src={`https://www.youtube.com/embed/${youtubeId}?autoplay=1&controls=0&mute=1&loop=1&modestbranding=1`}
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowFullScreen
+        title="Embedded youtube"
+      />
+    </div>
+  )
+}

--- a/packages/mirror-tv-next/components/topic/single-topic/hero-image.tsx
+++ b/packages/mirror-tv-next/components/topic/single-topic/hero-image.tsx
@@ -1,0 +1,30 @@
+'use client'
+import Image from 'next/image'
+import type { HeroImage } from '~/graphql/query/topic'
+import styles from '~/styles/components/topic/single-topic/hero-image.module.scss'
+
+type HeroImageProps = {
+  heroImage: HeroImage
+  alt: string
+}
+
+export default function HeroImage({ heroImage, alt }: HeroImageProps) {
+  return (
+    <section className={styles.sectionWrapper}>
+      <Image
+        src={
+          heroImage?.urlDesktopSized ||
+          heroImage?.urlTabletSized ||
+          heroImage?.urlMobileSized ||
+          heroImage?.urlOriginal ||
+          '/images/image-default.jpg'
+        }
+        alt={alt}
+        width={0}
+        height={0}
+        sizes="100vw"
+        style={{ width: '100%', height: 'auto' }}
+      />
+    </section>
+  )
+}

--- a/packages/mirror-tv-next/components/topic/single-topic/hero-video.tsx
+++ b/packages/mirror-tv-next/components/topic/single-topic/hero-video.tsx
@@ -1,0 +1,34 @@
+import ArticleContentVideo from '~/components/shared/article-content-video'
+import YoutubeEmbed from '~/components/shared/youtube-embed'
+
+type HeroVideoProps = {
+  videoSrc: string
+}
+
+export default function HeroVideo({ videoSrc }: HeroVideoProps) {
+  // Extract YouTube video ID from URL
+  const extractYoutubeId = (url: string) => {
+    const match = url.match(
+      /(?:https?:\/\/)?(?:www\.)?(?:youtube\.com\/(?:[^\/\n\s]+\/\S+\/|(?:v|e(?:mbed)?)\/|\S*?[?&]v=)|youtu\.be\/)([a-zA-Z0-9_-]{11})/
+    )
+    return match ? match[1] : null
+  }
+
+  // Check if the videoSrc is a YouTube URL
+  const isYoutubeUrl = (url: string) => {
+    return url.includes('youtube.com') || url.includes('youtu.be')
+  }
+
+  // Handle the videoSrc based on its type
+  const handleVideoSrc = (src: string) => {
+    if (isYoutubeUrl(src)) {
+      const youtubeId = extractYoutubeId(src)
+      if (youtubeId) {
+        return <YoutubeEmbed youtubeId={youtubeId} />
+      }
+    }
+    return <ArticleContentVideo videoSrc={src} />
+  }
+
+  return <section>{handleVideoSrc(videoSrc)}</section>
+}

--- a/packages/mirror-tv-next/graphql/query/topic.ts
+++ b/packages/mirror-tv-next/graphql/query/topic.ts
@@ -13,7 +13,7 @@ export type Topic = {
   } | null
 }
 
-type HeroImage = {
+export type HeroImage = {
   urlDesktopSized: string
   urlTabletSized: string
   urlMobileSized: string

--- a/packages/mirror-tv-next/next.config.js
+++ b/packages/mirror-tv-next/next.config.js
@@ -26,6 +26,11 @@ const nextConfig = {
         hostname: 'staging.mnews.tw',
         pathname: '**',
       },
+      {
+        protocol: 'https',
+        hostname: 'storage.googleapis.com',
+        pathname: '**',
+      },
     ],
   },
   output: 'standalone',

--- a/packages/mirror-tv-next/styles/components/shared/article-content-video.module.scss
+++ b/packages/mirror-tv-next/styles/components/shared/article-content-video.module.scss
@@ -1,0 +1,3 @@
+.videoWrapper video {
+  width: 100%;
+}

--- a/packages/mirror-tv-next/styles/components/shared/youtube-embed.module.scss
+++ b/packages/mirror-tv-next/styles/components/shared/youtube-embed.module.scss
@@ -1,0 +1,14 @@
+.videoWrapper {
+  overflow: hidden;
+  padding-bottom: 56.25%;
+  position: relative;
+  height: 0;
+
+  iframe {
+    left: 0;
+    top: 0;
+    height: 100%;
+    width: 100%;
+    position: absolute;
+  }
+}

--- a/packages/mirror-tv-next/styles/components/topic/single-topic/hero-image.module.scss
+++ b/packages/mirror-tv-next/styles/components/topic/single-topic/hero-image.module.scss
@@ -1,0 +1,4 @@
+.sectionWrapper {
+  width: 100vw;
+  object-fit: 'cover';
+}

--- a/packages/mirror-tv-next/styles/pages/single-topic-page.module.scss
+++ b/packages/mirror-tv-next/styles/pages/single-topic-page.module.scss
@@ -1,3 +1,11 @@
+@import '/styles/theme/breakpoints';
+
 .mainWrapper {
   min-height: 80dvh;
+
+  padding-top: 50px; /* the height of mobile nav*/
+
+  @include media-breakpoint-up(md) {
+    padding-top: 0;
+  }
 }


### PR DESCRIPTION
**feat:  leading type - video and image**
The hero section of single topic page has four types: `video`, `image`, `slideshow`, and `multivideo`. This PR handles the first two scenarios. Among them, the video type accepts two data formats, CMS URL and Youtube URL, which are rendered using `<YoutubeEmbed/>` and `<ArticleContentVideo/>` respectively to display corresponding embed videos. The requirements are all to be muted, autoplayed, looped, and to hide controls.