### PR TITLE
feat(tv-next): instantiate GTM via @next/third-parties/google

### DIFF
--- a/packages/mirror-tv-next/app/layout.tsx
+++ b/packages/mirror-tv-next/app/layout.tsx
@@ -1,9 +1,10 @@
+import { GoogleTagManager } from '@next/third-parties/google'
 import type { Metadata } from 'next'
 import { Noto_Sans } from 'next/font/google'
 import Footer from '~/components/layout/footer'
 import MainHeader from '~/components/layout/header/main-header'
 import { META_DESCRIPTION, SITE_TITLE } from '~/constants/constant'
-import { GLOBAL_CACHE_SETTING } from '~/constants/environment-variables'
+import { GLOBAL_CACHE_SETTING, GTM_ID } from '~/constants/environment-variables'
 import '../styles/global.css'
 
 export const revalidate = GLOBAL_CACHE_SETTING
@@ -27,6 +28,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="ch" className={`${noto_sans.variable} ${noto_sans.variable}`}>
+      <GoogleTagManager gtmId={GTM_ID} />
       <body>
         <>
           <MainHeader />

--- a/packages/mirror-tv-next/package.json
+++ b/packages/mirror-tv-next/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.8.0-rc.2",
+    "@next/third-parties": "^14.1.4",
     "@readr-media/react-image": "^2.2.1",
     "@svgr/webpack": "^8.1.0",
     "@twreporter/errors": "^1.1.2",


### PR DESCRIPTION
[Google Third-Parties](https://nextjs.org/docs/app/building-your-application/optimizing/third-party-libraries#google-third-parties)
All supported third-party libraries from Google can be imported from @next/third-parties/google.

[Google Tag Manager](https://nextjs.org/docs/app/building-your-application/optimizing/third-party-libraries#google-tag-manager)
The GoogleTagManager component can be used to instantiate a [Google Tag Manager](https://developers.google.com/tag-platform/tag-manager) container to your page. By default, it fetches the original inline script after hydration occurs on the page.