### PR TITLE
feat(tv-next): set up Google GPT ads environment and add demo test ads

### DIFF
--- a/packages/mirror-tv-next/app/layout.tsx
+++ b/packages/mirror-tv-next/app/layout.tsx
@@ -1,6 +1,7 @@
 import { GoogleTagManager } from '@next/third-parties/google'
 import type { Metadata } from 'next'
 import { Noto_Sans } from 'next/font/google'
+import Script from 'next/script'
 import Footer from '~/components/layout/footer'
 import MainHeader from '~/components/layout/header/main-header'
 import { META_DESCRIPTION, SITE_TITLE } from '~/constants/constant'
@@ -29,6 +30,43 @@ export default function RootLayout({
   return (
     <html lang="ch" className={`${noto_sans.variable} ${noto_sans.variable}`}>
       <GoogleTagManager gtmId={GTM_ID} />
+      <Script
+        async
+        src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"
+      />
+      <Script id="gpt-setup">
+        {`
+        window.googletag = window.googletag || {cmd: []};
+        window.googletag.cmd.push(() => {
+          /**
+           * Do not use lazy loading with SRA.
+           *
+           * With lazy loading in SRA,
+           * GPT will fetching multiple ads at the same time,
+           * which cause the call for the first ad and all other ad slots is made.
+           * https://developers.google.com/doubleclick-gpt/reference#googletag.PubAdsService_enableSingleRequest
+           */
+          // window.googletag.pubads().enableSingleRequest()
+
+          window.googletag.pubads().enableLazyLoad({
+            // Fetch slots within 1.5 viewports.
+            fetchMarginPercent: 150,
+
+            // Render slots within 1 viewports.
+            renderMarginPercent: 100,
+
+            /**
+             * Double the above values on mobile, where viewports are smaller
+             * and users tend to scroll faster.
+             */
+            mobileScaling: 2.0,
+          })
+          window.googletag.pubads().collapseEmptyDivs()
+          window.googletag.enableServices()
+
+          
+        })`}
+      </Script>
       <body>
         <>
           <MainHeader />

--- a/packages/mirror-tv-next/app/page.tsx
+++ b/packages/mirror-tv-next/app/page.tsx
@@ -1,5 +1,8 @@
+import dynamic from 'next/dynamic'
 import MainFlashNews from '~/components/flash-news/main-flash-news'
 import styles from '~/styles/pages/page.module.scss'
+
+const GPTAd = dynamic(() => import('~/components/ads/gpt/gpt-ad'))
 
 export default function Home() {
   return (
@@ -8,6 +11,11 @@ export default function Home() {
         <MainFlashNews />
       </div>
       <p>Hello, world.</p>
+      {/* Test GPT ADs */}
+      <div>
+        <GPTAd pageKey="story" adKey="PC_R2" />
+        <GPTAd pageKey="all" adKey="PC_HD" />
+      </div>
     </main>
   )
 }

--- a/packages/mirror-tv-next/components/ads/gpt/gpt-ad.tsx
+++ b/packages/mirror-tv-next/components/ads/gpt/gpt-ad.tsx
@@ -1,0 +1,202 @@
+'use client'
+import styles from '~/styles/components/ads/gpt-ad/gpt-ad.module.scss'
+
+import { useEffect, useState } from 'react'
+
+import {
+  getAdSlotParam,
+  getAdSlotParamByAdUnit,
+  getAdWidth,
+} from '~/utils/gpt-ad'
+
+type GPTAdProps = {
+  pageKey?: string
+  adKey?: string
+  adUnit?: string
+  onSlotRequested?: (event: unknown) => void
+  onSlotRenderEnded?: (event: unknown) => void
+  className?: string
+}
+
+type SingleSizeArray = [number, number]
+
+const GPTAdRoot = ({
+  pageKey,
+  adKey,
+  adUnit,
+  onSlotRequested,
+  onSlotRenderEnded,
+}: GPTAdProps) => {
+  const [adSize, setAdSize] = useState<SingleSizeArray[]>([])
+  const [adUnitPath, setAdUnitPath] = useState('')
+  const [adWidth, setAdWidth] = useState('')
+
+  const adDivId = adUnitPath // Set the id of the ad `<div>` to be the same as the `adUnitPath`.
+
+  useEffect(() => {
+    let newAdSize, newAdUnitPath, newAdWidth
+    if (pageKey && adKey) {
+      // built-in ad unit
+      const width = window.innerWidth
+      const adSlotParam = getAdSlotParam(pageKey, adKey, width)
+      if (!adSlotParam) {
+        return
+      }
+      const { adUnitPath, adSize } = adSlotParam
+      newAdSize = adSize
+      newAdUnitPath = adUnitPath
+      newAdWidth = getAdWidth(adSize)
+    } else if (adUnit) {
+      // custom ad unit string
+      const adSlotParam = getAdSlotParamByAdUnit(adUnit)
+      const { adUnitPath, adSize } = adSlotParam
+
+      newAdSize = adSize
+      newAdUnitPath = adUnitPath
+      newAdWidth = getAdWidth(adSize)
+    } else {
+      console.error(
+        `GPTAd not receive necessary pageKey '${pageKey}' and adKey '${adKey}' or adUnit '${adUnit}'`
+      )
+      return
+    }
+
+    setAdSize(newAdSize)
+    setAdWidth(newAdWidth)
+    setAdUnitPath(newAdUnitPath)
+  }, [adKey, pageKey, adUnit])
+
+  useEffect(() => {
+    if (adDivId && adWidth && window.googletag) {
+      /**
+       * Check https://developers.google.com/publisher-tag/guides/get-started?hl=en for the tutorial of the flow.
+       */
+      let adSlot: string
+
+      const handleOnSlotRequested = (event: { slot: string }) => {
+        if (event.slot === adSlot && onSlotRequested) {
+          onSlotRequested(event)
+        }
+      }
+
+      const handleOnSlotRenderEnded = (event: { slot: string }) => {
+        if (event.slot === adSlot && onSlotRenderEnded) {
+          onSlotRenderEnded(event)
+        }
+      }
+
+      window.googletag.cmd.push(() => {
+        const pubads = window.googletag.pubads()
+
+        adSlot = window.googletag
+          .defineSlot(adUnitPath, adSize, adDivId)
+          .addService(window.googletag.pubads())
+        window.googletag.display(adDivId)
+
+        // all events, check https://developers.google.com/publisher-tag/reference?hl=en#googletag.events.eventtypemap for all events
+        if (onSlotRequested) {
+          /**
+           * add event listener  to respond only to certain adSlot
+           * @see https://developers.google.com/publisher-tag/reference?hl=zh-tw#googletag.Service_addEventListener
+           */
+          pubads.addEventListener('slotRequested', handleOnSlotRequested)
+        }
+        if (onSlotRenderEnded) {
+          pubads.addEventListener('slotRenderEnded', handleOnSlotRenderEnded)
+        }
+      })
+
+      return () => {
+        const pubads = window.googletag.pubads()
+
+        window.googletag.cmd.push(() => {
+          window.googletag.destroySlots([adSlot])
+          if (onSlotRenderEnded) {
+            pubads.removeEventListener('slotRequested', handleOnSlotRequested)
+          }
+          if (onSlotRenderEnded) {
+            pubads.removeEventListener(
+              'slotRenderEnded',
+              handleOnSlotRenderEnded
+            )
+          }
+        })
+      }
+    }
+  }, [adDivId, adSize, adUnitPath, adWidth, onSlotRenderEnded, onSlotRequested])
+
+  return (
+    <div className={`${styles.wrapper} gpt-ad`}>
+      <div
+        className={styles.ad}
+        style={{
+          maxWidth: '100%',
+          textAlign: 'center',
+          width: adWidth || 'unset',
+        }}
+        id={adDivId}
+      />
+    </div>
+  )
+}
+
+export default function GptAd({
+  pageKey,
+  adKey,
+  adUnit,
+  onSlotRequested,
+  onSlotRenderEnded,
+  className,
+}: GPTAdProps) {
+  const [shouldShowAd, setShouldAd] = useState(false)
+  const isBuildInAdUnit = pageKey && adKey
+  const isCustomAdUnit = adUnit
+  const isValidAd = isBuildInAdUnit || isCustomAdUnit
+
+  /**
+   * If adKey contain 'MB', which means this ad should only render at device which viewport is smaller then 1200px.
+   * If adKey contain 'PC', which means this ad should only render at device which viewport is smaller larger 1200px.
+   *
+   * Why we use `window.innerWidth` to decide should show GPT ad, not just using css `@media-query`?
+   * Because in GPT ad, ad unit will load even if ad is unseen (`display: none`).
+   * The inconsistency between the loading and rendering of ads does not align with our business logic.
+   */
+  useEffect(() => {
+    const width = window.innerWidth
+
+    if (!width || !isValidAd) {
+      return
+    }
+    const isDesktopWidth = width >= 1200
+    if (isBuildInAdUnit) {
+      switch (true) {
+        case adKey?.includes('MB'):
+          setShouldAd(!isDesktopWidth)
+          return
+        case adKey?.includes('PC'):
+          setShouldAd(isDesktopWidth)
+          return
+        default:
+          setShouldAd(true)
+          return
+      }
+    } else if (isCustomAdUnit) {
+      setShouldAd(true)
+      return
+    }
+  }, [adKey, pageKey, isBuildInAdUnit, isCustomAdUnit, isValidAd])
+  return (
+    <>
+      {shouldShowAd && isValidAd ? (
+        <GPTAdRoot
+          className={className}
+          pageKey={pageKey}
+          adKey={adKey}
+          adUnit={adUnit}
+          onSlotRenderEnded={onSlotRenderEnded}
+          onSlotRequested={onSlotRequested}
+        ></GPTAdRoot>
+      ) : null}
+    </>
+  )
+}

--- a/packages/mirror-tv-next/constants/ads.ts
+++ b/packages/mirror-tv-next/constants/ads.ts
@@ -1,0 +1,372 @@
+/**
+ * page key（比如 global、[news]）註解中各項文字代表的涵義：
+ * // page key: spreadsheet 的「分類」欄位, spreadsheet 的「section」欄位
+ */
+
+/**
+ * ad key（比如 RWD_LOGO、MB_HD）是怎麼決定的：spreadsheet 的「device」欄位_spreadsheet 的「position」欄位
+ *
+ * 構建 ad key 的程式碼如下：
+ * const adKey = [
+ *   device === 'm' ? 'MB' : device.toUpperCase(),
+ *   position.toUpperCase(),
+ * ].join('_')
+ */
+const GPT_UNITS = {
+  // page key: fs，蓋版廣告
+  fs: {
+    // ad key
+    MB_HOME: {
+      adUnit: 'mnews_m_320x480_Home',
+      adSize: [
+        [320, 480],
+        [1, 1],
+      ],
+    },
+    MB_CATEGORY: {
+      adUnit: 'mnews_m_320x480_category',
+      adSize: [
+        [320, 480],
+        [1, 1],
+      ],
+    },
+    MB_NEWS: {
+      adUnit: 'mnews_m_320x480_News',
+      adSize: [
+        [320, 480],
+        [1, 1],
+      ],
+    },
+    MB_PROGRAM: {
+      adUnit: 'mnews_m_320x480_program',
+      adSize: [
+        [320, 480],
+        [1, 1],
+      ],
+    },
+    MB_VIDEO: {
+      adUnit: 'mnews_m_320x480_video',
+      adSize: [
+        [320, 480],
+        [1, 1],
+      ],
+    },
+  },
+  // page key: all，全站
+  all: {
+    PC_HD: {
+      adUnit: 'mnews_masthead_top_970x400',
+      adSize: [
+        [970, 400],
+        [970, 250],
+        [970, 90],
+        [1, 1],
+      ],
+    },
+  },
+  // page key: home，首頁
+  home: {
+    // ad key
+    PC_R1: {
+      adUnit: 'mnews_home_sidebar_300x250_01',
+      adSize: [
+        [300, 250],
+        [1, 1],
+      ],
+    },
+    PC_R2: {
+      adUnit: 'mnews_home_sidebar_300x250_02',
+      adSize: [
+        [300, 250],
+        [1, 1],
+      ],
+    },
+    PC_BT: {
+      adUnit: 'mnews_home_900x280',
+      adSize: [
+        [900, 280],
+        [1, 1],
+      ],
+    },
+    MB_M1: {
+      adUnit: 'mnews_m_home_300x250_01',
+      adSize: [
+        [300, 250],
+        [336, 280],
+        [1, 1],
+      ],
+    },
+    MB_M2: {
+      adUnit: 'mnews_m_home_300x250_02',
+      adSize: [
+        [300, 250],
+        [336, 280],
+        [320, 480],
+        [1, 1],
+      ],
+    },
+    MB_M3: {
+      adUnit: 'mnews_m_home_300x250_03',
+      adSize: [
+        [300, 250],
+        [336, 280],
+        [1, 1],
+      ],
+    },
+    MB_M4: {
+      adUnit: 'mnews_m_home_300x250_04',
+      adSize: [
+        [300, 250],
+        [336, 280],
+        [1, 1],
+      ],
+    },
+  },
+  // page key: story，文章頁
+  story: {
+    // ad key
+    PC_R1: {
+      adUnit: 'mnews_article_sidebar_300x250_01',
+      adSize: [
+        [300, 250],
+        [1, 1],
+      ],
+    },
+    PC_R2: {
+      adUnit: 'mnews_article_sidebar_300x250_02',
+      adSize: [
+        [300, 250],
+        [1, 1],
+      ],
+    },
+    PC_R3: {
+      adUnit: 'mnews_article_sidebar_300x250_03',
+      adSize: [
+        [300, 250],
+        [1, 1],
+      ],
+    },
+    PC_AT1: {
+      adUnit: 'mnews_article_middle_300x250_01',
+      adSize: [
+        [300, 250],
+        [1, 1],
+      ],
+    },
+    PC_E1: {
+      adUnit: 'mnews_article_end_left_300x250',
+      adSize: [
+        [300, 250],
+        [1, 1],
+      ],
+    },
+    PC_E2: {
+      adUnit: 'mnews_article_end_right_300x250',
+      adSize: [
+        [300, 250],
+        [1, 1],
+      ],
+    },
+    MB_M1: {
+      adUnit: 'mnews_m_article_top_300x250',
+      adSize: [
+        [300, 250],
+        [336, 280],
+        [1, 1],
+      ],
+    },
+    MB_M2: {
+      adUnit: 'mnews_m_article_middle_300x250',
+      adSize: [
+        [300, 250],
+        [336, 280],
+        [320, 480],
+        [1, 1],
+      ],
+    },
+    MB_M3: {
+      adUnit: 'mnews_m_article_end_300x250_04',
+      adSize: [
+        [300, 250],
+        [336, 280],
+        [1, 1],
+      ],
+    },
+  },
+  // page key: category，分類頁
+  category: {
+    // ad key
+    PC_R1: {
+      adUnit: 'mnews_category_sidebar_300x250_01',
+      adSize: [
+        [300, 250],
+        [1, 1],
+      ],
+    },
+    PC_R2: {
+      adUnit: 'mnews_category_sidebar_300x250_02',
+      adSize: [
+        [300, 250],
+        [1, 1],
+      ],
+    },
+    PC_BT: {
+      adUnit: 'mnews_category_900x280',
+      adSize: [
+        [900, 280],
+        [1, 1],
+      ],
+    },
+    MB_M1: {
+      adUnit: 'mnews_m_category_top_300x250',
+      adSize: [
+        [300, 250],
+        [336, 280],
+        [1, 1],
+      ],
+    },
+    MB_M2: {
+      adUnit: 'mnews_m_category_middle_300x250',
+      adSize: [
+        [300, 250],
+        [336, 280],
+        [320, 480],
+        [1, 1],
+      ],
+    },
+    MB_M3: {
+      adUnit: 'mnews_m_category_end_300x250_04',
+      adSize: [
+        [300, 250],
+        [336, 280],
+        [1, 1],
+      ],
+    },
+  },
+  // page key: video，影音頁
+  video: {
+    // ad key
+    PC_R1: {
+      adUnit: 'mnews_video_sidebar_300x250_01',
+      adSize: [
+        [300, 250],
+        [1, 1],
+      ],
+    },
+    PC_R2: {
+      adUnit: 'mnews_video_sidebar_300x250_02',
+      adSize: [
+        [300, 250],
+        [1, 1],
+      ],
+    },
+    PC_R3: {
+      adUnit: 'mnews_video_sidebar_300x600_03',
+      adSize: [
+        [300, 600],
+        [1, 1],
+      ],
+    },
+    PC_BT: {
+      adUnit: 'mnews_video_900x280',
+      adSize: [
+        [900, 280],
+        [1, 1],
+      ],
+    },
+    MB_M1: {
+      adUnit: 'mnews_m_video_300x250_01',
+      adSize: [
+        [300, 250],
+        [336, 280],
+        [1, 1],
+      ],
+    },
+    MB_M2: {
+      adUnit: 'mnews_m_video_300x250_02',
+      adSize: [
+        [300, 250],
+        [336, 280],
+        [320, 480],
+        [1, 1],
+      ],
+    },
+    MB_M3: {
+      adUnit: 'mnews_m_video_300x250_03',
+      adSize: [
+        [300, 250],
+        [336, 280],
+        [1, 1],
+      ],
+    },
+    MB_M4: {
+      adUnit: 'mnews_m_video_300x250_04',
+      adSize: [
+        [300, 250],
+        [336, 280],
+        [1, 1],
+      ],
+    },
+  },
+  // page key: show，節目頁
+  show: {
+    // ad key
+    PC_R1: {
+      adUnit: 'mnews_program_sidebar_300x250_01',
+      adSize: [
+        [300, 250],
+        [1, 1],
+      ],
+    },
+    PC_R2: {
+      adUnit: 'mnews_program_sidebar_300x250_02',
+      adSize: [
+        [300, 250],
+        [1, 1],
+      ],
+    },
+    PC_R3: {
+      adUnit: 'mnews_program_sidebar_300x600_03',
+      adSize: [
+        [300, 600],
+        [1, 1],
+      ],
+    },
+    PC_BT: {
+      adUnit: 'mnews_program_900x280',
+      adSize: [
+        [900, 280],
+        [1, 1],
+      ],
+    },
+    MB_M1: {
+      adUnit: 'mnews_m_program_top_300x250',
+      adSize: [
+        [300, 250],
+        [336, 280],
+        [1, 1],
+      ],
+    },
+    MB_M2: {
+      adUnit: 'mnews_m_program_middle_300x250',
+      adSize: [
+        [300, 250],
+        [336, 280],
+        [320, 480],
+        [1, 1],
+      ],
+    },
+    MB_M3: {
+      adUnit: 'mnews_m_program_end_300x250_04',
+      adSize: [
+        [300, 250],
+        [336, 280],
+        [1, 1],
+      ],
+    },
+  },
+}
+
+const GPT_AD_NETWORK = '22699107359'
+
+export { GPT_AD_NETWORK, GPT_UNITS }

--- a/packages/mirror-tv-next/constants/ads.ts
+++ b/packages/mirror-tv-next/constants/ads.ts
@@ -12,7 +12,18 @@
  *   position.toUpperCase(),
  * ].join('_')
  */
-const GPT_UNITS = {
+
+// Define GPT_UNITS type
+type SingleSizeArray = [number, number]
+interface GPTUnits {
+  [pageKey: string]: {
+    [adKey: string]: {
+      adUnit: string
+      adSize: SingleSizeArray[]
+    }
+  }
+}
+const GPT_UNITS: GPTUnits = {
   // page key: fs，蓋版廣告
   fs: {
     // ad key
@@ -369,4 +380,13 @@ const GPT_UNITS = {
 
 const GPT_AD_NETWORK = '22699107359'
 
-export { GPT_AD_NETWORK, GPT_UNITS }
+const mediaSize = {
+  xs: 0,
+  sm: 576,
+  md: 768,
+  lg: 992,
+  xl: 1200,
+  xxl: 1440,
+}
+
+export { GPT_AD_NETWORK, GPT_UNITS, mediaSize }

--- a/packages/mirror-tv-next/styles/components/ads/gpt-ad/gpt-ad.module.scss
+++ b/packages/mirror-tv-next/styles/components/ads/gpt-ad/gpt-ad.module.scss
@@ -1,0 +1,26 @@
+.wrapper {
+  /**
+ * 廣告有時會替換掉原本 <Ad> 元件裡頭的根元素 <div>
+ * 因此不限定所指定的元素類型（*）
+ * 以確保能選擇到 Wrapper 的直接子元素
+ */
+  & > * {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    iframe {
+      display: block;
+    }
+  }
+}
+
+.ad {
+  max-width: 100%;
+  text-align: center;
+
+  /* don't use 'align-items: center;' to prevent gpt layout issue */
+  iframe {
+    margin-left: auto;
+    margin-right: auto;
+  }
+}

--- a/packages/mirror-tv-next/utils/gpt-ad.ts
+++ b/packages/mirror-tv-next/utils/gpt-ad.ts
@@ -1,0 +1,140 @@
+import { GPT_AD_NETWORK, GPT_UNITS, mediaSize } from '~/constants/ads'
+
+/**
+ * Generate the width of the ad's wrapper div.
+ * For GPT ads, there will be three types of adSize 'fixed', 'multi', 'fluid'.
+ * Since we only use 'multi' type (ex: [[300, 250], [1, 1]]),
+ * the adWidth caculation will use 'multi' type caclulatin directly.
+ */
+
+type SingleSizeArray = [number, number]
+
+export function getAdWidth(adSize: SingleSizeArray[]): string {
+  const widthMax = adSize?.reduce((acc, curr) => Math.max(curr[0], acc), 0)
+  return widthMax ? `${widthMax}px` : '0px'
+}
+
+function getDevice(width: number) {
+  const isDesktopWidth = width >= mediaSize.xl
+  return isDesktopWidth ? 'PC' : 'MB'
+}
+
+/**
+ * Generate full key like 'PC_HD' if the component support dynamic device adKey like 'HD'
+ */
+function getAdFullKey(device: 'PC' | 'MB', adKey: string): string {
+  return adKey.includes('_') ? adKey : `${device}_${adKey}`
+}
+
+interface GPTAdData {
+  adUnit: string
+  adSize: SingleSizeArray[]
+}
+
+/**
+ * Get GPT_UNITS adData
+ * @param pageKey - Key to access GPT_UNITS first layer
+ * @param adKey - Key to access GPT_UNITS second layer, might need to complete with device
+ * @param width - Browser width
+ * @returns GPTAdData if found, otherwise undefined
+ */
+function getAdData(
+  pageKey: string,
+  adKey: string,
+  width: number
+): GPTAdData | undefined {
+  const device = getDevice(width)
+  const adFullKey = getAdFullKey(device, adKey)
+  const adData = GPT_UNITS[pageKey][adFullKey]
+
+  if (!adData) {
+    console.error(
+      `Unable to find the AD data. Got the pageKey "${pageKey}" and adKey "${adFullKey}". Please provide a valid pageKey or adKey.`
+    )
+  }
+
+  return adData
+}
+
+/**
+ * Generate adSlot params for googletag.defineSlot.
+ */
+export interface GPTAdSlotParam {
+  adUnitPath: string
+  adSize: SingleSizeArray[]
+}
+
+/**
+ * Generate adSlot params for googletag.defineSlot.
+ * @param pageKey - Key to access GPT_UNITS first layer
+ * @param adKey - Key to access GPT_UNITS second layer, might need to complete with device
+ * @param width - Browser width
+ * @returns GPTAdSlotParam
+ */
+export function getAdSlotParam(
+  pageKey: string,
+  adKey: string,
+  width: number
+): GPTAdSlotParam | undefined {
+  const adData = getAdData(pageKey, adKey, width)
+  if (!adData) {
+    return
+  }
+  const { adUnit, adSize } = adData
+  const adUnitPath = getAdUnitPath(adUnit)
+  return { adUnitPath, adSize }
+}
+
+/**
+ * Create adSize array with size string like '970250'.
+ * @param sizeString - Size string
+ * @returns SingleSizeArray
+ */
+function createAdSize(sizeString: string): SingleSizeArray {
+  return [
+    parseInt(sizeString.substring(0, 3)),
+    parseInt(sizeString.substring(3)),
+  ]
+}
+
+/**
+ * Create adSize with special adUnit string like 'mirror_RWD_2022FIFA_970250-300250_FT'.
+ * @param adUnit - Special adUnit string for topic page
+ * @returns SingleSizeArray[] if valid adSize found, otherwise undefined
+ */
+function getAdSize(adUnit: string): SingleSizeArray[] | undefined {
+  const adUnitSlices = adUnit.split('_')
+  let hasNan = false
+  const adSize = adUnitSlices[adUnitSlices.length - 2]
+    ?.split('-')
+    .map((sizeString) => {
+      const singleAdSize = createAdSize(sizeString)
+      if (isNaN(singleAdSize[0]) || isNaN(singleAdSize[1])) {
+        hasNan = true
+      }
+      return singleAdSize
+    })
+
+  return hasNan ? undefined : adSize
+}
+
+/**
+ * Generate adUnitPath for given adUnit.
+ * @param adUnit - AdUnit string
+ * @returns AdUnit path
+ */
+function getAdUnitPath(adUnit: string): string {
+  return `/${GPT_AD_NETWORK}/${adUnit}`
+}
+
+/**
+ * Generate adSlot params for googletag.defineSlot.
+ * Especially for custom adUnit in CMS like topic DFP field.
+ * @param adUnit - AdUnit string
+ * @returns GPTAdSlotParam
+ */
+export function getAdSlotParamByAdUnit(adUnit: string): GPTAdSlotParam {
+  const adUnitPath = getAdUnitPath(adUnit)
+  const adSize = getAdSize(adUnit) || []
+  return { adUnitPath, adSize }
+}


### PR DESCRIPTION
- Added necessary configurations for integrating Google GPT ads into the project
- Configured ad slots for different page contexts
- Added a demo test ad unit for demonstration purposes

This commit sets up the environment for Google GPT ads and includes a demo test ad unit to showcase the integration. The necessary configurations have been added to support ad rendering on different pages according to the provided ad keys.

You can see the ads by modifying the local host name. Use `sudo vim /etc/hosts` to edit the hosts file and change it to `http://local.mnews.tw:3000`.
<img width="1346" alt="Screen Shot 2024-04-07 at 12 47 55 PM" src="https://github.com/mirror-tv/Tabris/assets/66411169/a9dc5b93-bfb9-42ad-b5aa-2565d6884985">
