### PR TITLE
style(tv-next): add _size-hide.scss

### DIFF
--- a/packages/mirror-tv-next/styles/pages/category-video-page.module.scss
+++ b/packages/mirror-tv-next/styles/pages/category-video-page.module.scss
@@ -1,4 +1,5 @@
 @import '/styles/theme/breakpoints';
+@import '/styles/theme/size-hide';
 
 .main {
   margin: 0 auto;
@@ -51,10 +52,8 @@
 }
 
 .desktopOnly {
-  display: none;
-  @include media-breakpoint-up(xl) {
-    display: block;
-  }
+  @extend .desktop-hide;
+  @extend .tablet-hide;
 }
 
 .mobileOnly {
@@ -62,7 +61,5 @@
   @include media-breakpoint-up(md) {
     padding: 0;
   }
-  @include media-breakpoint-up(xl) {
-    display: none;
-  }
+  @extend .desktop-hide;
 }

--- a/packages/mirror-tv-next/styles/pages/page.module.scss
+++ b/packages/mirror-tv-next/styles/pages/page.module.scss
@@ -1,4 +1,5 @@
 @import '/styles/theme/breakpoints';
+@import '/styles/theme/size-hide';
 
 .main {
   min-height: 100dvh;
@@ -14,7 +15,7 @@
   padding: 0 8px;
   width: 100%;
 
-  @include media-breakpoint-up(md) {
-    display: none;
-  }
+  // mobile only
+  @extend .tablet-hide;
+  @extend .desktop-hide;
 }

--- a/packages/mirror-tv-next/styles/theme/_breakpoints.scss
+++ b/packages/mirror-tv-next/styles/theme/_breakpoints.scss
@@ -1,27 +1,32 @@
+// _breakpoints.scss
+$breakpoints: (
+  sm: 576px,
+  md: 768px,
+  lg: 960px,
+  xl: 1200px,
+  xxl: 1400px,
+);
+
 @mixin media-breakpoint-up($point) {
-  @if $point == sm {
-    @media (min-width: 576px) {
+  $min-width: map-get($breakpoints, $point);
+
+  @if $min-width {
+    @media (min-width: $min-width) {
       @content;
     }
+  } @else {
+    @warn "No breakpoint defined for `#{$point}`.";
   }
-  @elseif $point == md {
-    @media (min-width: 768px) {
+}
+
+@mixin media-breakpoint-down($point) {
+  $max-width: map-get($breakpoints, $point);
+
+  @if $max-width {
+    @media (max-width: $max-width) {
       @content;
     }
-  }
-  @elseif $point == lg {
-    @media (min-width: 960px) {
-      @content;
-    }
-  }
-  @elseif $point == xl {
-    @media (min-width: 1200px) {
-      @content;
-    }
-  }
-  @elseif $point == xxl {
-    @media (min-width: 1400px) {
-      @content;
-    }
+  } @else {
+    @warn "No breakpoint defined for `#{$point}`.";
   }
 }

--- a/packages/mirror-tv-next/styles/theme/_size-hide.scss
+++ b/packages/mirror-tv-next/styles/theme/_size-hide.scss
@@ -1,0 +1,25 @@
+// size-hide.scss
+@import 'breakpoints';
+
+// Mobile-hide: 在手機版（md）以下隱藏
+.mobile-hide {
+  @include media-breakpoint-down(md) {
+    display: none;
+  }
+}
+
+// Tablet-hide: 在桌機版（md ~ xl）隱藏
+.tablet-hide {
+  @include media-breakpoint-up(md) {
+    @include media-breakpoint-down(xl) {
+      display: none;
+    }
+  }
+}
+
+// Desktop-hide: 大於等於 xl 時隱藏
+.desktop-hide {
+  @include media-breakpoint-up(xl) {
+    display: none;
+  }
+}


### PR DESCRIPTION
### 描述
- 改寫 [_breakpoints.scss](https://github.com/mirror-tv/Tabris/compare/dev...v61265:Tabris:0527-hide?expand=1#diff-101cdecf85a564ce38e8ebb1990bc6979a5be32941ad1ae96d11eaf1d22a19f3)，將 breakpoints 單獨抽出來。
- 製作 `_size-hide` 邏輯，以 xl 和 md 尺寸為分界，分出三種尺寸下要 `display: none` 的狀況。
- 不確定會不會太難懂，請求 code review！另外有個問題是如果要套用處原本有宣告其他 display 就會無條件被蓋過（加上 important？）。