### PR TITLE
fix(mm-tv): change image plugin for sponsors

### DIFF
--- a/packages/mirror-tv-next/components/layout/header/mobile-header/side-menu.tsx
+++ b/packages/mirror-tv-next/components/layout/header/mobile-header/side-menu.tsx
@@ -1,5 +1,6 @@
 'use client'
 import Image from 'next/image'
+import CallbackImage from '@readr-media/react-image'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useEffect, useState } from 'react'
@@ -8,6 +9,7 @@ import type { Category } from '~/graphql/query/category'
 import type { Show } from '~/graphql/query/shows'
 import type { Sponsor } from '~/graphql/query/sponsors'
 import styles from './_styles/side-menu.module.scss'
+import { formateHeroImage } from '~/utils'
 
 type SideMenuProps = {
   categories: Category[]
@@ -97,6 +99,7 @@ export default function SideMenu({
         <div className={styles.sponsorsBlock}>
           <div className={styles.sponsorsWrapper}>
             {sponsors.slice(0, 3).map((sponsor) => {
+              const formattedLogo = formateHeroImage(sponsor.logo ?? {})
               return (
                 <div key={sponsor.id}>
                   <Link
@@ -106,19 +109,13 @@ export default function SideMenu({
                         : `/topic/${sponsor.topic?.slug}`
                     }
                   >
-                    <Image
-                      src={
-                        sponsor.logo?.urlMobileSized ??
-                        '/images/image-default.jpg'
-                      }
+                    <CallbackImage
                       alt="Sponsor Logo"
-                      width={100}
-                      height={52}
-                      priority
-                      style={{
-                        width: 100,
-                        height: 52,
-                      }}
+                      images={formattedLogo}
+                      loadingImage="/images/loading.svg"
+                      defaultImage="/images/image-default.jpg"
+                      rwd={{ default: '100px' }}
+                      priority={true}
                     />
                   </Link>
                 </div>


### PR DESCRIPTION
### 描述
- prod 無法正常顯示在 header 的 sponsors。
- 出現問題如下 ` ⨯ Error: Invalid src prop (https://statics.mnews.tw/assets/images/clpe56n1300q510oq62b9hqdb-mobile.jpg) on next/image, hostname "statics.mnews.tw" is not configured under images in your next.config.js
See more info: https://nextjs.org/docs/messages/next-image-unconfigured-host`
- 雖然也可以在 config 檔案新增白名單，但不確定使用者之後會在該處使用什麼新的 domain，乾脆統一改成使用 `@readr-media/react-image` 套件。