### PR TITLE
fix(mm-tv): change image plugin for sponsors

### DIFF
--- a/packages/mirror-tv-next/app/anchorperson/[slug]/page.tsx
+++ b/packages/mirror-tv-next/app/anchorperson/[slug]/page.tsx
@@ -170,7 +170,7 @@ export default async function singleAnchor({
               </div>
             </div>
             <div className={styles.bio}>
-              {bio.map((item: { id: string; content: string }) => (
+              {bio.map((item) => (
                 <div key={item.id}>{item.content && <p>{item.content}</p>}</div>
               ))}
             </div>

--- a/packages/mirror-tv-next/components/layout/header/_styles/header-top.module.scss
+++ b/packages/mirror-tv-next/components/layout/header/_styles/header-top.module.scss
@@ -42,3 +42,21 @@
     gap: 10px;
   }
 }
+
+.sponsorItem {
+  display: block;
+  position: relative;
+  width: 100px;
+  height: 52px;
+  overflow: hidden;
+  object-fit: contain;
+
+  img {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    max-width: 100px;
+    max-height: 52px;
+  }
+}

--- a/packages/mirror-tv-next/components/layout/header/header-top.tsx
+++ b/packages/mirror-tv-next/components/layout/header/header-top.tsx
@@ -2,8 +2,15 @@ import Image from 'next/image'
 import Link from 'next/link'
 import styles from './_styles/header-top.module.scss'
 import HeaderSearchBar from './header-search-bar'
+import type { Sponsor } from '~/graphql/query/sponsors'
+import { formateHeroImage } from '~/utils'
+import ResponsiveImage from '~/components/shared/responsive-image'
 
-export default function HeaderTop() {
+type HeaderTopProps = {
+  sponsors: Sponsor[]
+}
+
+export default function HeaderTop({ sponsors }: HeaderTopProps) {
   return (
     <div className={styles.wrapper}>
       <div className={[styles.logo, 'top-wrapper__left'].join(' ')}>
@@ -18,6 +25,28 @@ export default function HeaderTop() {
         </Link>
       </div>
       <HeaderSearchBar />
+      <div className={styles.sponsorsWrapper}>
+        {sponsors.slice(0, 3).map((sponsor) => {
+          const formattedLogo = formateHeroImage(sponsor.logo ?? {})
+          return (
+            <div key={sponsor.id}>
+              <Link
+                href={
+                  sponsor.url ? sponsor.url : `/topic/${sponsor.topic?.slug}`
+                }
+                className={styles.sponsorItem}
+              >
+                <ResponsiveImage
+                  alt="Sponsor Logo"
+                  images={formattedLogo}
+                  rwd={{ default: '100px' }}
+                  priority={true}
+                />
+              </Link>
+            </div>
+          )
+        })}
+      </div>
     </div>
   )
 }

--- a/packages/mirror-tv-next/components/layout/header/mobile-header/_styles/side-menu.module.scss
+++ b/packages/mirror-tv-next/components/layout/header/mobile-header/_styles/side-menu.module.scss
@@ -36,6 +36,24 @@
   overflow: hidden;
 }
 
+.sponsorItem {
+  display: block;
+  position: relative;
+  width: 100px;
+  height: 52px;
+  overflow: hidden;
+  object-fit: contain;
+
+  img {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    max-width: 100px;
+    max-height: 52px;
+  }
+}
+
 .categoriesBlock {
   background: #153047;
   display: flex;

--- a/packages/mirror-tv-next/components/layout/header/mobile-header/side-menu.tsx
+++ b/packages/mirror-tv-next/components/layout/header/mobile-header/side-menu.tsx
@@ -108,6 +108,7 @@ export default function SideMenu({
                         ? sponsor.url
                         : `/topic/${sponsor.topic?.slug}`
                     }
+                    className={styles.sponsorItem}
                   >
                     <CallbackImage
                       alt="Sponsor Logo"

--- a/packages/mirror-tv-next/components/layout/header/mobile-header/side-menu.tsx
+++ b/packages/mirror-tv-next/components/layout/header/mobile-header/side-menu.tsx
@@ -1,5 +1,6 @@
 'use client'
 import Image from 'next/image'
+import CallbackImage from '@readr-media/react-image'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useEffect, useState } from 'react'
@@ -8,6 +9,7 @@ import type { Category } from '~/graphql/query/category'
 import type { Show } from '~/graphql/query/shows'
 import type { Sponsor } from '~/graphql/query/sponsors'
 import styles from './_styles/side-menu.module.scss'
+import { formateHeroImage } from '~/utils'
 
 type SideMenuProps = {
   categories: Category[]
@@ -97,6 +99,7 @@ export default function SideMenu({
         <div className={styles.sponsorsBlock}>
           <div className={styles.sponsorsWrapper}>
             {sponsors.slice(0, 3).map((sponsor) => {
+              const formattedLogo = formateHeroImage(sponsor.logo ?? {})
               return (
                 <div key={sponsor.id}>
                   <Link
@@ -106,19 +109,13 @@ export default function SideMenu({
                         : `/topic/${sponsor.topic?.slug}`
                     }
                   >
-                    <Image
-                      src={
-                        sponsor.logo?.urlMobileSized ??
-                        '/images/image-default.jpg'
-                      }
+                    <CallbackImage
                       alt="Sponsor Logo"
-                      width={100}
-                      height={52}
-                      priority
-                      style={{
-                        width: 100,
-                        height: 52,
-                      }}
+                      images={formattedLogo}
+                      loadingImage="/images/loading.svg"
+                      defaultImage="/images/image-default.jpg"
+                      rwd={{ default: '100px' }}
+                      priority={true}
                     />
                   </Link>
                 </div>


### PR DESCRIPTION
### 描述
1. 修改 header sponsors 放法，原本用 `next/image` 會需要建立圖片網域白名單，為了防止亂放統一改成 `@readr-media/react-image` 套件。
2. 桌機版 header sponsors 不知道為什麼消失了，加回來。