### PR TITLE
feat(search-page-result): highlight search keywords

### DIFF
--- a/packages/mirror-tv-next/components/search/search-result.tsx
+++ b/packages/mirror-tv-next/components/search/search-result.tsx
@@ -38,7 +38,7 @@ const SearchResult = ({
       ),
       postStyle: 'article',
       mobileLayoutDirection: 'column' as const,
-      postTitleHighlightText: '',
+      postTitleHighlightText: keyword,
     }
   }
   const handleClickLoadMore = async (page: number) => {

--- a/packages/mirror-tv-next/components/shared/ui-post-card.tsx
+++ b/packages/mirror-tv-next/components/shared/ui-post-card.tsx
@@ -27,17 +27,20 @@ export default function UiPostCard({
 
   // keyword 時有些字體會被 height light
   const highlightTextProducer = (title: string): string | TrustedHTML => {
-    const highlightTextProducer = (text: string) => {
+    // If no keyword is provided, return the original title
+    if (!postTitleHighlightText) return title
+
+    const wrapInHighlightSpan = (text: string): string => {
       return `<span style="color: #014db8">${text}</span>`
     }
-    const re = new RegExp(title.split(' ').join('|'), 'gi')
-    return title.replace(re, function (matchedText) {
-      return highlightTextProducer(matchedText)
-    })
+
+    // Create a case-insensitive regular expression to find the keyword
+    const highlightRegex = new RegExp(postTitleHighlightText, 'gi')
+
+    return title.replace(highlightRegex, wrapInHighlightSpan)
   }
-  const postTitleProcessed = postTitleHighlightText
-    ? highlightTextProducer(title)
-    : title
+
+  const postTitleProcessed = highlightTextProducer(title)
 
   return (
     <a


### PR DESCRIPTION
## 功能
1. 搜尋的文字highlight
2. 如果沒有相對應的文字，或是沒有搜尋文字就直接回傳原本標題

![搜尋結果參考圖](https://github.com/user-attachments/assets/c3feaaff-e4c6-4e88-a8fe-20252694c902)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207683098811035