### PR TITLE
feat(tv/homepage): add live-cam section on homepage

### DIFF
--- a/packages/mirror-tv-next/app/_actions/homepage/video.tsx
+++ b/packages/mirror-tv-next/app/_actions/homepage/video.tsx
@@ -1,0 +1,51 @@
+'use server'
+import errors from '@twreporter/errors'
+import { getClient } from '~/apollo-client'
+import type { Video } from '~/graphql/query/videos'
+import { getVideoByName } from '~/graphql/query/videos'
+
+type getVideoType = {
+  name: string
+  take: number
+  errorMessage?: string
+}
+
+async function getVideo({
+  name,
+  take,
+  errorMessage = '',
+}: getVideoType): Promise<
+  | {
+      data: { allVideos: Video[] }
+    }
+  | undefined
+> {
+  const client = getClient()
+  try {
+    const { data } = await client.query<{ allVideos: Video[] }>({
+      query: getVideoByName,
+      variables: {
+        name,
+        take,
+      },
+    })
+    return { data }
+  } catch (err) {
+    const annotatingError = errors.helpers.wrap(
+      err,
+      'UnhandledError',
+      errorMessage ?? `Error occurs while fetching ${name} videos in homepage`
+    )
+    console.error(
+      JSON.stringify({
+        severity: 'ERROR',
+        message: errors.helpers.printAll(annotatingError, {
+          withStack: false,
+          withPayload: true,
+        }),
+      })
+    )
+  }
+}
+
+export { getVideo }

--- a/packages/mirror-tv-next/app/_actions/share/video.tsx
+++ b/packages/mirror-tv-next/app/_actions/share/video.tsx
@@ -4,7 +4,7 @@ import { getClient } from '~/apollo-client'
 import type { Video } from '~/graphql/query/videos'
 import { getVideoByName } from '~/graphql/query/videos'
 
-type getVideoType = {
+type GetVideoType = {
   name: string
   take: number
   errorMessage?: string
@@ -14,12 +14,9 @@ async function getVideo({
   name,
   take,
   errorMessage = '',
-}: getVideoType): Promise<
-  | {
-      data: { allVideos: Video[] }
-    }
-  | undefined
-> {
+}: GetVideoType): Promise<{
+  data: { allVideos: Video[] }
+}> {
   const client = getClient()
   try {
     const { data } = await client.query<{ allVideos: Video[] }>({
@@ -45,6 +42,7 @@ async function getVideo({
         }),
       })
     )
+    return { data: { allVideos: [] } }
   }
 }
 

--- a/packages/mirror-tv-next/app/category/video/page.tsx
+++ b/packages/mirror-tv-next/app/category/video/page.tsx
@@ -19,7 +19,6 @@ import { HEADER_JSON_URL } from '~/constants/environment-variables'
 import type { HeaderData } from '~/types/header'
 import type { PromotionVideo } from '~/graphql/query/promotion-video'
 import { getPromotionVideos } from '~/graphql/query/promotion-video'
-import { getVideoByName } from '~/graphql/query/videos'
 import type { Video } from '~/graphql/query/videos'
 import AsideVideoListHandler from '~/components/category/video/aside-video-list-handler'
 import type { VideoEditorChoice } from '~/graphql/query/video-editor-choice'
@@ -33,6 +32,7 @@ import {
   GPTPlaceholderDesktop,
 } from '~/components/ads/gpt/gpt-placeholder'
 import UiAsideVideosList from '~/components/shared/ui-aside-videos-list'
+import { getVideo } from '~/app/_actions/share/video'
 
 export const revalidate = GLOBAL_CACHE_SETTING
 
@@ -110,27 +110,9 @@ export default async function VideoCategoryPage() {
       query: getPromotionVideos,
     })
 
-  const fetchOtherStreaming = () =>
-    client.query<{
-      allVideos: Video[]
-    }>({
-      query: getVideoByName,
-      variables: {
-        name: 'live-cam',
-        take: 2,
-      },
-    })
+  const fetchOtherStreaming = () => getVideo({ name: 'live-cam', take: 2 })
 
-  const fetchLiveVideo = () =>
-    client.query<{
-      allVideos: Video[]
-    }>({
-      query: getVideoByName,
-      variables: {
-        name: 'mnews-live',
-        take: 1,
-      },
-    })
+  const fetchLiveVideo = () => getVideo({ name: 'mnews-live', take: 1 })
 
   const fetchVideoEditorChoice = () =>
     client.query<{ allVideoEditorChoices: VideoEditorChoice[] }>({
@@ -211,6 +193,7 @@ export default async function VideoCategoryPage() {
     },
     'Error occurs while fetching live videos in video category page'
   )
+
   allVideoEditorChoices = handleResponse(
     responses[6],
     (data: Awaited<ReturnType<typeof fetchVideoEditorChoice>> | undefined) => {

--- a/packages/mirror-tv-next/app/page.tsx
+++ b/packages/mirror-tv-next/app/page.tsx
@@ -7,6 +7,7 @@ import GptPopup from '~/components/ads/gpt/gpt-popup'
 import { GLOBAL_CACHE_SETTING } from '~/constants/environment-variables'
 import PopularPostsList from '~/components/homepage/popular-posts-list'
 import TopicList from '~/components/homepage/topic-list'
+import LiveCamList from '~/components/homepage/live-cam-list'
 
 const GPTAd = dynamic(() => import('~/components/ads/gpt/gpt-ad'))
 
@@ -29,6 +30,7 @@ export default function Home() {
         <MainFlashNews />
       </div>
       <PopularPostsList title="熱門新聞" />
+      <LiveCamList title="直播現場" />
       <TopicList title="推薦專題" />
     </main>
   )

--- a/packages/mirror-tv-next/components/homepage/_styles/live-cam-list.module.scss
+++ b/packages/mirror-tv-next/components/homepage/_styles/live-cam-list.module.scss
@@ -1,0 +1,56 @@
+@import '/styles/theme/breakpoints';
+@import '/styles/theme/variable';
+
+.container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(180deg, #153047 0, #000);
+  min-width: 100vw;
+  max-width: 100vw;
+  padding: 36px 0;
+  display: flex;
+  flex-direction: column;
+  @include media-breakpoint-up(md) {
+    padding: 28px 0;
+  }
+  @include media-breakpoint-up(xl) {
+    padding: 32px 0;
+  }
+}
+
+.listTitle {
+  margin-bottom: 32px;
+  border-image: linear-gradient(
+      to bottom,
+      #fff 35%,
+      transparent 35%,
+      transparent 65%,
+      #fff 65%
+    )
+    5 !important;
+  min-width: 110px;
+  @include media-breakpoint-up(md) {
+    margin-bottom: 28px;
+  }
+
+  p {
+    color: #fff;
+  }
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  @include media-breakpoint-up(xl) {
+    flex-direction: row;
+  }
+}
+
+.item {
+  width: 100dvw;
+  @include media-breakpoint-up(md) {
+    width: 497px;
+  }
+}

--- a/packages/mirror-tv-next/components/homepage/live-cam-list.tsx
+++ b/packages/mirror-tv-next/components/homepage/live-cam-list.tsx
@@ -1,0 +1,49 @@
+import styles from './_styles/live-cam-list.module.scss'
+import UiHeadingBordered from '~/components/shared/ui-heading-bordered'
+import type { Video } from '~/graphql/query/videos'
+import { getVideo } from '~/app/_actions/homepage/video'
+import YoutubeEmbed from '../shared/youtube-embed'
+import { extractYoutubeId } from '~/utils'
+
+type LiveCamListProps = {
+  title: string
+}
+
+export default async function LiveCamList({ title }: LiveCamListProps) {
+  let allLiveVideo: Video[] | undefined = []
+
+  try {
+    const response = await getVideo({ name: 'live-cam', take: 2 })
+    allLiveVideo = response?.data?.allVideos
+  } catch (error) {
+    return null
+  }
+
+  if (!allLiveVideo?.[0]) {
+    return null
+  }
+
+  return (
+    <section className={styles.container}>
+      <UiHeadingBordered title={title} className={styles.listTitle} />
+      <div>
+        <div className={styles.list}>
+          {allLiveVideo.map((video) => {
+            const youtubeId = extractYoutubeId(video.youtubeUrl || video.url)
+            return (
+              <YoutubeEmbed
+                className={styles.item}
+                key={video.id}
+                youtubeId={youtubeId}
+                autoplay={false}
+                muted={false}
+                loop={true}
+                controls={true}
+              />
+            )
+          })}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/packages/mirror-tv-next/components/homepage/live-cam-list.tsx
+++ b/packages/mirror-tv-next/components/homepage/live-cam-list.tsx
@@ -1,7 +1,7 @@
 import styles from './_styles/live-cam-list.module.scss'
 import UiHeadingBordered from '~/components/shared/ui-heading-bordered'
 import type { Video } from '~/graphql/query/videos'
-import { getVideo } from '~/app/_actions/homepage/video'
+import { getVideo } from '~/app/_actions/share/video'
 import YoutubeEmbed from '../shared/youtube-embed'
 import { extractYoutubeId } from '~/utils'
 

--- a/packages/mirror-tv-next/components/shared/_styles/youtube-embed.module.scss
+++ b/packages/mirror-tv-next/components/shared/_styles/youtube-embed.module.scss
@@ -1,7 +1,7 @@
 .videoWrapper {
   overflow: hidden;
   position: relative;
-  aspect-ratio: calc(1 / 0.5625);
+  aspect-ratio: calc(16 / 9);
 
   iframe {
     left: 0;

--- a/packages/mirror-tv-next/components/shared/_styles/youtube-embed.module.scss
+++ b/packages/mirror-tv-next/components/shared/_styles/youtube-embed.module.scss
@@ -1,8 +1,7 @@
 .videoWrapper {
   overflow: hidden;
-  padding-bottom: 56.25%;
   position: relative;
-  height: 0;
+  aspect-ratio: calc(1 / 0.5625);
 
   iframe {
     left: 0;


### PR DESCRIPTION
### 描述
新增首頁「直播現場」區塊。

### 參考資料
- [asana 卡片](https://app.asana.com/0/1208642030547628/1205934387535993/f)
- [1.0 現有頁面資料](https://dev.mnews.tw/)
- [figma 設計稿](https://www.figma.com/design/BATB1ux8KjfWYa4DV1Xm3t/2024_%E9%8F%A1%E9%9B%BB%E8%A6%96_Web?node-id=8323-3851&node-type=rounded_rectangle&m=dev)

### 提問
- `/category/video` 頁面也有抓過 live-cam 兩則，初步判斷是不需要存入 useContext，不過有需要共用 server action 嗎（目前另一頁是直接在 page 層打），這樣是比較好的寫法還是 over designed？