### PR TITLE
feat(amp): add heroVideo and heroInfo

### DIFF
--- a/packages/mirror-tv-next/amp.d.ts
+++ b/packages/mirror-tv-next/amp.d.ts
@@ -19,7 +19,15 @@ declare namespace JSX {
       React.VideoHTMLAttributes<HTMLVideoElement>,
       HTMLVideoElement
     >
-
+    'amp-youtube': React.DetailedHTMLProps<
+      React.HTMLAttributes<HTMLElement>,
+      HTMLElement
+    > & {
+      'data-videoid': string
+      width?: string | number
+      height?: string | number
+      layout?: string
+    }
     'amp-script': React.DetailedHTMLProps<
       React.HTMLAttributes<HTMLElement>,
       HTMLElement

--- a/packages/mirror-tv-next/components/story/amp/hero-info.tsx
+++ b/packages/mirror-tv-next/components/story/amp/hero-info.tsx
@@ -1,0 +1,122 @@
+import styled from 'styled-components'
+import { CONTACT_MAPPING } from '~/constants/constant'
+import { type SinglePost } from '~/graphql/query/story'
+import { formateDateAtTaipei } from '~/utils'
+
+const CategoryAndPublishTime = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 0 0 8px;
+`
+
+const Category = styled.span`
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 1.4;
+  color: #014db8;
+`
+
+const PublishTime = styled.span`
+  font-size: 14px;
+  line-height: 1.5;
+  color: #000;
+`
+
+const StyledTitle = styled.h1`
+  font-size: 20px;
+  font-weight: 500;
+  line-height: 1.4;
+  color: #000;
+  margin: 0 0 8px;
+`
+
+const CreditsWrapper = styled.ul`
+  margin: 0 0 24px;
+  list-style-type: none;
+  padding: 0;
+`
+
+const CreditItem = styled.li`
+  display: inline-block;
+  font-size: 14px;
+  line-height: 1.4;
+  margin: 0 12px 0 0;
+`
+
+type HeroInfoProps = {
+  title: string
+  publishTime: string
+  categories: SinglePost['categories']
+  writers: SinglePost['writers']
+  photographers: SinglePost['photographers']
+  cameraOperators: SinglePost['cameraOperators']
+  designers: SinglePost['designers']
+  engineers: SinglePost['engineers']
+  vocals: SinglePost['vocals']
+  otherbyline: string
+}
+
+export default function HeroInfo({
+  title,
+  publishTime,
+  categories,
+  writers,
+  photographers,
+  cameraOperators,
+  designers,
+  engineers,
+  vocals,
+  otherbyline,
+}: HeroInfoProps) {
+  const creditList = Object.entries(CONTACT_MAPPING)
+    .map(([key, title]) => ({
+      title,
+      list:
+        {
+          writers,
+          photographers,
+          cameraOperators,
+          designers,
+          engineers,
+          vocals,
+        }[key as keyof typeof CONTACT_MAPPING] || [],
+    }))
+    .filter(({ list }) => list.length > 0)
+  const publishTimeTaipei = formateDateAtTaipei(
+    new Date(publishTime),
+    'YYYY.MM.DD HH:mm',
+    '臺北時間'
+  )
+
+  return (
+    <>
+      <CategoryAndPublishTime className='class="amp__main__category-publishTime"'>
+        <Category className="amp-pub-cat-category">
+          {categories?.[0]?.title}
+        </Category>
+        {publishTime && (
+          <PublishTime className="amp-pub-cat-publishTime">
+            {publishTimeTaipei}
+          </PublishTime>
+        )}
+      </CategoryAndPublishTime>
+      <StyledTitle>{title}</StyledTitle>
+      {creditList.length && (
+        <CreditsWrapper>
+          {creditList.map((item) => {
+            return (
+              <CreditItem key={item.title}>
+                {item.title}｜
+                {item.list?.map(
+                  (person, key) => `${key ? '、' : ''}${person.name}`
+                )}
+              </CreditItem>
+            )
+          })}
+          <CreditItem key="other">{otherbyline}</CreditItem>
+        </CreditsWrapper>
+      )}
+    </>
+  )
+}

--- a/packages/mirror-tv-next/constants/constant.ts
+++ b/packages/mirror-tv-next/constants/constant.ts
@@ -28,6 +28,15 @@ const HOMEPAGE_POSTS_PAGE_SIZE = 12
 
 const SALES_LABEL_NAME = '特企'
 
+const CONTACT_MAPPING = {
+  writers: '記者',
+  photographers: '攝影',
+  cameraOperators: '影音',
+  designers: '設計',
+  engineers: '工程',
+  vocals: '主播',
+}
+
 export {
   HEADER_BOTTOM_LINKS,
   META_DESCRIPTION,
@@ -36,4 +45,5 @@ export {
   URL_PROGRAMABLE_SEARCH,
   HOMEPAGE_POSTS_PAGE_SIZE,
   SALES_LABEL_NAME,
+  CONTACT_MAPPING,
 }

--- a/packages/mirror-tv-next/graphql/query/story.ts
+++ b/packages/mirror-tv-next/graphql/query/story.ts
@@ -5,8 +5,20 @@ export interface SingleRelatedPost {
   name: string
 }
 
+export interface SinglePersonInfo {
+  slug: string
+  name: string
+}
+
 export interface SinglePost {
+  id: string
+  title: string
+  style: string
+  publishTime: string
   relatedPosts: SingleRelatedPost[]
+  heroVideo: {
+    youtubeUrl: string
+  }
   heroImage: {
     id: string
     name: string
@@ -17,12 +29,30 @@ export interface SinglePost {
     urlTinySized: string
   }
   heroCaption: string
+  categories: {
+    slug: string
+    title: string
+  }[]
+  writers: SinglePersonInfo[]
+  photographers: SinglePersonInfo[]
+  cameraOperators: SinglePersonInfo[]
+  designers: SinglePersonInfo[]
+  engineers: SinglePersonInfo[]
+  vocals: SinglePersonInfo[]
+  otherbyline: string
   __typename: string
 }
 
 const fetchStoryBySlug = gql`
   query fetchStoryBySlug($slug: String!) {
     allPosts(where: { slug: $slug, state_not_in: invisible }) {
+      id
+      title: name
+      style
+      publishTime
+      heroVideo {
+        youtubeUrl
+      }
       heroImage {
         id
         name
@@ -33,6 +63,35 @@ const fetchStoryBySlug = gql`
         urlTinySized
       }
       heroCaption
+      categories {
+        slug
+        title: name
+      }
+      writers {
+        name
+        slug
+      }
+      photographers {
+        name
+        slug
+      }
+      cameraOperators {
+        name
+        slug
+      }
+      designers {
+        name
+        slug
+      }
+      engineers {
+        name
+        slug
+      }
+      vocals {
+        name
+        slug
+      }
+      otherbyline
       relatedPosts(where: { state: published }) {
         slug
         name

--- a/packages/mirror-tv-next/pages/story/amp/[slug]/index.tsx
+++ b/packages/mirror-tv-next/pages/story/amp/[slug]/index.tsx
@@ -18,11 +18,13 @@ import {
   type FormattedPostCardJson,
   formatArticleCard,
   handleResponse,
+  extractYoutubeId,
 } from '~/utils'
 import { type RawPopularPost } from '~/types/popular-post'
 import { PostCardItem } from '~/graphql/query/posts'
 import RelatedPostList from '~/components/story/amp/related-post-list'
 import { getLatestPostsFunction } from '~/utils/fetch-function'
+import HeroInfo from '~/components/story/amp/hero-info'
 
 export const config = { amp: true }
 
@@ -32,6 +34,7 @@ const ImageWrapper = styled.figure`
   margin: 0;
   height: calc(100vw * 0.66);
   overflow: hidden;
+  margin-left: -16px;
   img {
     object-fit: cover;
     object-position: center;
@@ -42,8 +45,21 @@ const HeroImhCaption = styled.figcaption`
   font-size: 14px;
   line-height: 1.5;
   color: #000;
-  padding: 0 16px;
   margin: 8px 0 0;
+`
+
+const Main = styled.main`
+  padding: 0 16px;
+  margin: 0 0 48px;
+`
+
+const HeroImageAndVideo = styled.section`
+  margin-bottom: 24px;
+
+  .hero-video {
+    width: 100vw;
+    margin-left: -16px;
+  }
 `
 
 export default function AmpPage({
@@ -52,15 +68,58 @@ export default function AmpPage({
   latestPostsList,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   if (!storyData) return null
-  const { heroImage = {}, heroCaption = '', relatedPosts = [] } = storyData
-  const heroSrc = getHeroImageOfAmp(formateHeroImage(heroImage))
+  const {
+    heroImage = {},
+    heroCaption = '',
+    relatedPosts = [],
+    title = '',
+    publishTime = '',
+    categories = [],
+    writers,
+    photographers,
+    cameraOperators,
+    designers,
+    engineers,
+    vocals,
+    otherbyline,
+    style = 'article',
+    heroVideo = { youtubeUrl: '' },
+  } = storyData
+  const heroImgSrc = getHeroImageOfAmp(formateHeroImage(heroImage))
+  const heroVideoId = extractYoutubeId(heroVideo?.youtubeUrl) ?? ''
 
   return (
     <AMPLayout>
-      <ImageWrapper>
-        <amp-img src={heroSrc} layout="fill" />
-      </ImageWrapper>
-      {heroCaption && <HeroImhCaption>{heroCaption}</HeroImhCaption>}
+      <Main>
+        <HeroImageAndVideo>
+          {style === 'videoNews' && heroVideoId ? (
+            <amp-youtube
+              data-videoid={heroVideoId}
+              width="480"
+              height="270"
+              layout="responsive"
+              className="hero-video"
+            ></amp-youtube>
+          ) : (
+            <ImageWrapper>
+              <amp-img src={heroImgSrc} layout="fill" />
+            </ImageWrapper>
+          )}
+          {heroCaption && <HeroImhCaption>{heroCaption}</HeroImhCaption>}
+        </HeroImageAndVideo>
+        <HeroInfo
+          title={title}
+          publishTime={publishTime}
+          categories={categories}
+          writers={writers}
+          photographers={photographers}
+          cameraOperators={cameraOperators}
+          designers={designers}
+          engineers={engineers}
+          vocals={vocals}
+          otherbyline={otherbyline}
+        />
+      </Main>
       {!!relatedPosts.length && (
         <RelatedPostList title="相關新聞" list={relatedPosts} />
       )}


### PR DESCRIPTION
### 描述
- 新增 amp 頁面文章本體上方的 hero video 和其他相關資訊。

### 參考資料
- [asana 卡片](https://app.asana.com/1/614399484723017/project/1209439757061078/task/1209303424485701?focus=true)
- [1.0 頁面](https://dev.mnews.tw/story/amp/mm-20210719edi038)