### PR TITLE
refactor(recall): replace static feature toggle with dynamic recall display config from json

### DIFF
--- a/packages/mirror-tv-next/app/page.tsx
+++ b/packages/mirror-tv-next/app/page.tsx
@@ -7,6 +7,8 @@ import GptPopup from '~/components/ads/gpt/gpt-popup'
 import {
   GLOBAL_CACHE_SETTING,
   HOMEPAGE_SON_URL,
+  ENV,
+  RECALL_DISPLAY_JSON_URL,
 } from '~/constants/environment-variables'
 import PopularPostsList from '~/components/homepage/popular-posts-list'
 import TopicList from '~/components/homepage/topic-list'
@@ -14,7 +16,6 @@ import LiveCamList from '~/components/homepage/live-cam-list'
 import ShowList from '~/components/homepage/show-list-init'
 import LatestAndEditorchoicesWithLive from '~/components/homepage/latest-and-editor-choices-with-live'
 import errors from '@twreporter/errors'
-import { RECALL_FEATURE_TOGGLE_2025 } from '~/constants/environment-variables'
 import RecallIframe from '~/components/homepage/recall-iframe'
 
 const GPTAd = dynamic(() => import('~/components/ads/gpt/gpt-ad'))
@@ -30,10 +31,20 @@ export default async function Home() {
     allVideos: [],
     allPromotionVideos: [],
   }
+
+  let IS_SHOW_RECALL_2025 = false
+
   try {
     homepageJsonData = await fetch(HOMEPAGE_SON_URL, {
       next: { revalidate: GLOBAL_CACHE_SETTING },
     }).then((res) => res.json())
+    const recallDisplayJsonData = await fetch(RECALL_DISPLAY_JSON_URL, {
+      next: { revalidate: GLOBAL_CACHE_SETTING },
+    }).then((res) => res.json())
+    IS_SHOW_RECALL_2025 =
+      recallDisplayJsonData[
+        ENV === 'local' ? `display_iframe_dev` : `display_iframe_${ENV}`
+      ] === 'TRUE'
   } catch (err) {
     const annotatingError = errors.helpers.wrap(
       err,
@@ -68,7 +79,7 @@ export default async function Home() {
       <div className={styles.mobFlashNewsWrapper}>
         <MainFlashNews />
       </div>
-      {RECALL_FEATURE_TOGGLE_2025 === 'True' && <RecallIframe />}
+      {IS_SHOW_RECALL_2025 && <RecallIframe />}
       <LatestAndEditorchoicesWithLive
         latestListTitle="即時新聞"
         liveData={homepageJsonData.allVideos?.[0]}

--- a/packages/mirror-tv-next/constants/environment-variables.ts
+++ b/packages/mirror-tv-next/constants/environment-variables.ts
@@ -1,6 +1,5 @@
 // 這裡管理的是在 Build 階段就會寫死數值的環境變數 (通常為 `NEXT_PUBLCI_` 開頭)
 const ENV = process.env.NEXT_PUBLIC_ENV || 'local'
-const RECALL_FEATURE_TOGGLE_2025 = process.env.NEXT_PUBLIC_SPECIALEVENT
 let SITE_URL: string
 let GTM_ID: string
 let GLOBAL_CACHE_SETTING: number
@@ -13,6 +12,8 @@ let YOUTUBE_API_URL: string
 let FEATURE_POSTS_URL: string
 let HOMEPAGE_SON_URL: string =
   'https://storage.googleapis.com/static-mnews-tw-dev/files/json/topic_video.json'
+const RECALL_DISPLAY_JSON_URL =
+  'https://storage.googleapis.com/whoareyou-gcs.readr.tw/json/202507_recall_homepage_display.json'
 let GA4_ID: string
 
 switch (ENV) {
@@ -96,5 +97,5 @@ export {
   FEATURE_POSTS_URL,
   HOMEPAGE_SON_URL,
   GA4_ID,
-  RECALL_FEATURE_TOGGLE_2025,
+  RECALL_DISPLAY_JSON_URL,
 }


### PR DESCRIPTION
## 描述
- 將原本以環境變數 `RECALL_FEATURE_TOGGLE_2025` 控制的「罷免 iframe」顯示邏輯，改為從 JSON（`RECALL_DISPLAY_JSON_URL`）動態取得顯示設定
- 根據不同環境讀取對應欄位，判斷是否顯示 RecallIframe
- 移除不再使用的 `RECALL_FEATURE_TOGGLE_2025` 相關 code
- 增加 const `RECALL_DISPLAY_JSON_URL`，統一管理

### 參考資料
- [slack 討論串](https://mirrormedia.slack.com/archives/C3HAC7SKV/p1753078624823889)