### PR TITLE
refactor(category): set og image dynamically from feature, post, or external

### DIFF
--- a/packages/mirror-tv-next/app/category/[slug]/page.tsx
+++ b/packages/mirror-tv-next/app/category/[slug]/page.tsx
@@ -30,6 +30,10 @@ import { fetchCategoryData } from '~/app/_actions/category/category-data'
 
 export const revalidate = GLOBAL_CACHE_SETTING
 
+type FeaturePostsResponse = {
+  allPosts: FeaturePost[]
+}
+
 export async function generateMetadata({
   params,
 }: {
@@ -38,13 +42,97 @@ export async function generateMetadata({
   const { slug } = params
   const categoryData = await fetchCategoryData(slug)
 
+  let firstPost = null
+
+  const fetchFeaturePosts = (): Promise<FeaturePostsResponse> =>
+    fetch(FEATURE_POSTS_URL).then((res) => res.json())
+
+  const [featurePostResult] = await Promise.allSettled([fetchFeaturePosts()])
+
+  firstPost = handleResponse(
+    featurePostResult,
+    (response: Awaited<ReturnType<typeof fetchFeaturePosts>> | undefined) => {
+      if (!response?.allPosts) return null
+      const post = response.allPosts.find((post: FeaturePost) => {
+        return post.categories.some((category) => {
+          return category.id === categoryData.id
+        })
+      })
+      return post ? formatArticleCard(post) : null
+    },
+    'Error occurs while fetching category feature posts data in category page'
+  )
+
+  let ogImage = '/images/default-og-img.jpg'
+  if (firstPost) {
+    ogImage = firstPost.images.w3200 ?? '/images/default-og-img.jpg'
+  } else {
+    const fetchCategoryPosts = () =>
+      fetchPostsByCategory({
+        skip: 0,
+        categorySlug: categoryData.slug,
+        pageSize: 1,
+        isWithCount: false,
+        filteredSlug: [],
+      })
+    const fetchCategoryExternals = () =>
+      fetchExternalsByCategory({
+        skip: 0,
+        categorySlug: categoryData.slug,
+        pageSize: 1,
+        isWithCount: false,
+        filteredSlug: [],
+      })
+
+    const [postsResult, externalsResult] = await Promise.allSettled([
+      fetchCategoryPosts(),
+      fetchCategoryExternals(),
+    ])
+
+    const categoryPosts = handleResponse(
+      postsResult,
+      (
+        postResponse: Awaited<ReturnType<typeof fetchCategoryPosts>> | undefined
+      ) => {
+        return (
+          postResponse?.allPosts?.map((post) => formatArticleCard(post)) ?? []
+        )
+      },
+      'Error occurs while fetching category posts data in category page'
+    )
+
+    const externals = handleResponse(
+      externalsResult,
+      (
+        response: Awaited<ReturnType<typeof fetchCategoryExternals>> | undefined
+      ) => {
+        return (
+          response?.allExternals?.map((post) => formatArticleCard(post)) ?? []
+        )
+      },
+      'Error occurs while fetching category externals data in category page'
+    )
+
+    const newestPostIsExternal =
+      (externals?.length &&
+        categoryPosts?.length &&
+        new Date(externals[0].publishTime) >
+          new Date(categoryPosts[0].publishTime)) ||
+      !categoryPosts?.length
+    if (newestPostIsExternal) {
+      ogImage = externals[0].images.w3200 ?? '/images/default-og-img.jpg'
+    } else {
+      ogImage = categoryPosts[0].images.w3200 ?? '/images/default-og-img.jpg'
+    }
+  }
+
   return {
     metadataBase: new URL(SITE_URL),
     title: `${categoryData.name} - 鏡新聞`,
     openGraph: {
       title: `${categoryData.name} - 鏡新聞`,
       images: {
-        url: '/images/default-og-img.jpg',
+        url: ogImage,
       },
     },
   }
@@ -63,10 +151,6 @@ export default async function CategoryPage({
 
   categoryData = await fetchCategoryData(params.slug)
   if (!categoryData.name) return notFound()
-
-  type FeaturePostsResponse = {
-    allPosts: FeaturePost[]
-  }
 
   const fetchFeaturePosts = (): Promise<FeaturePostsResponse> =>
     fetch(FEATURE_POSTS_URL).then((res) => res.json())

--- a/packages/mirror-tv-next/components/category/posts-list-manager.tsx
+++ b/packages/mirror-tv-next/components/category/posts-list-manager.tsx
@@ -36,7 +36,6 @@ export default function PostsListManager({
   externals,
   categoryPosts,
 }: PostsListManagerProps) {
-  console.log({ externals })
   const isExternal = (post: FormattedPostCard) => post.__typename === 'External'
   const initPostsList = combineAndSortedByPublishedTime([
     ...categoryPosts,


### PR DESCRIPTION
- refactor generateMetadata，讓 og image 依序優先採用 feature post、最新一般文章或最新 external 的圖片
- 若皆無則 fallback 至預設 og image

## 參考資料
- [asana](https://app.asana.com/1/614399484723017/project/1210828396831826/task/1210554287093136)