### PR TITLE
refactor: add order fields (name, schedule) and update sorting logic

### DIFF
--- a/packages/tv-ad-admin-next/app/api/list/orders/route.ts
+++ b/packages/tv-ad-admin-next/app/api/list/orders/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server'
 import { getOrdersQuery } from '@/graphql/queries/orders'
 import { type OrderRecordForList } from '@/types/order'
 import { getClient } from '@/utils/apollo-client'
+import { formatTaiwanDate } from '@/utils/date'
 import { createErrorLogger } from '@/utils/error-handler'
 
 export async function GET() {
@@ -17,8 +18,13 @@ export async function GET() {
     })
 
     const orders = data?.orders || []
+    const formattedOrders = orders.map((order) => ({
+      ...order,
+      scheduleStartDate: formatTaiwanDate(order.scheduleStartDate),
+      scheduleEndDate: formatTaiwanDate(order.scheduleEndDate),
+    }))
 
-    return NextResponse.json({ orders })
+    return NextResponse.json({ orders: formattedOrders })
   } catch (error) {
     createErrorLogger('Failed to fetch orders list')(error)
 

--- a/packages/tv-ad-admin-next/app/api/list/orders/route.ts
+++ b/packages/tv-ad-admin-next/app/api/list/orders/route.ts
@@ -20,8 +20,8 @@ export async function GET() {
     const orders = data?.orders || []
     const formattedOrders = orders.map((order) => ({
       ...order,
-      scheduleStartDate: formatTaiwanDate(order.scheduleStartDate),
-      scheduleEndDate: formatTaiwanDate(order.scheduleEndDate),
+      scheduleStartDateString: formatTaiwanDate(order.scheduleStartDate),
+      scheduleEndDateString: formatTaiwanDate(order.scheduleEndDate),
     }))
 
     return NextResponse.json({ orders: formattedOrders })

--- a/packages/tv-ad-admin-next/components/list/order-row.tsx
+++ b/packages/tv-ad-admin-next/components/list/order-row.tsx
@@ -17,7 +17,7 @@ export function OrderRow({
   onViewOrder,
   isRelated = false,
 }: OrderRowProps) {
-  const { id, state, updatedAt } = order
+  const { state, updatedAt, name, orderNumber, schedule } = order
   const rowContent = [
     {
       key: 'number',
@@ -26,14 +26,14 @@ export function OrderRow({
           {isRelated && (
             <ArrowRightDownIcon className="mr-2 h-4 w-4 text-gray-400" />
           )}
-          # {id}
+          # {orderNumber}
         </div>
       ),
     },
-    { key: 'name', content: `未命名` },
-    { key: 'broadcastDate', content: `未排播` },
+    { key: 'name', content: name },
+    { key: 'broadcastDate', content: schedule },
     { key: 'state', content: <StateBadge state={state} /> },
-    { key: 'updatedAt', content: updatedAt || `未更新` },
+    { key: 'updatedAt', content: updatedAt },
     {
       key: 'moreBtn',
       content: (

--- a/packages/tv-ad-admin-next/components/list/order-row.tsx
+++ b/packages/tv-ad-admin-next/components/list/order-row.tsx
@@ -6,7 +6,7 @@ import { type OrderRecordForList } from '@/types/order'
 
 type OrderRowProps = {
   order: OrderRecordForList
-  onViewOrder: (orderId: string) => void
+  onViewOrder: (orderId: number) => void
   isRelated?: boolean
 }
 
@@ -22,8 +22,8 @@ export function OrderRow({
     updatedAt,
     name,
     orderNumber,
-    scheduleStartDate,
-    scheduleEndDate,
+    scheduleStartDateString,
+    scheduleEndDateString,
   } = order
   console.log(order)
   const rowContent = [
@@ -41,7 +41,7 @@ export function OrderRow({
     { key: 'name', content: name || '-' },
     {
       key: 'broadcastDate',
-      content: `${scheduleStartDate} - ${scheduleEndDate}`,
+      content: `${scheduleStartDateString} - ${scheduleEndDateString}`,
     },
     { key: 'state', content: <StateBadge state={state} /> },
     { key: 'updatedAt', content: updatedAt || '-' },

--- a/packages/tv-ad-admin-next/components/list/order-row.tsx
+++ b/packages/tv-ad-admin-next/components/list/order-row.tsx
@@ -17,7 +17,15 @@ export function OrderRow({
   onViewOrder,
   isRelated = false,
 }: OrderRowProps) {
-  const { state, updatedAt, name, orderNumber, schedule } = order
+  const {
+    state,
+    updatedAt,
+    name,
+    orderNumber,
+    scheduleStartDate,
+    scheduleEndDate,
+  } = order
+  console.log(order)
   const rowContent = [
     {
       key: 'number',
@@ -30,10 +38,13 @@ export function OrderRow({
         </div>
       ),
     },
-    { key: 'name', content: name },
-    { key: 'broadcastDate', content: schedule },
+    { key: 'name', content: name || '-' },
+    {
+      key: 'broadcastDate',
+      content: `${scheduleStartDate} - ${scheduleEndDate}`,
+    },
     { key: 'state', content: <StateBadge state={state} /> },
-    { key: 'updatedAt', content: updatedAt },
+    { key: 'updatedAt', content: updatedAt || '-' },
     {
       key: 'moreBtn',
       content: (

--- a/packages/tv-ad-admin-next/graphql/queries/orders.ts
+++ b/packages/tv-ad-admin-next/graphql/queries/orders.ts
@@ -4,7 +4,10 @@ export const getOrdersQuery = gql`
   query getOrders($where: OrderWhereInput, $orderBy: [OrderOrderByInput!]) {
     orders(where: $where, orderBy: $orderBy) {
       id
+      orderNumber
+      name
       state
+      schedule
       createdAt
       updatedAt
       relatedOrder {

--- a/packages/tv-ad-admin-next/graphql/queries/orders.ts
+++ b/packages/tv-ad-admin-next/graphql/queries/orders.ts
@@ -7,7 +7,8 @@ export const getOrdersQuery = gql`
       orderNumber
       name
       state
-      schedule
+      scheduleStartDate
+      scheduleEndDate
       createdAt
       updatedAt
       relatedOrder {

--- a/packages/tv-ad-admin-next/types/order.ts
+++ b/packages/tv-ad-admin-next/types/order.ts
@@ -3,8 +3,8 @@ import { type OrderState } from '@/constants'
 export type OrderRecord = {
   id: string
   orderNumber: string
-  productName: string
-  broadcastDate: string
+  name: string
+  schedule: string
   state: OrderState
   relatedOrder?: OrderRecord
   createdAt: string
@@ -13,7 +13,13 @@ export type OrderRecord = {
 
 export type OrderRecordForList = Pick<
   OrderRecord,
-  'id' | 'orderNumber' | 'state' | 'createdAt' | 'updatedAt'
+  | 'id'
+  | 'orderNumber'
+  | 'name'
+  | 'state'
+  | 'schedule'
+  | 'createdAt'
+  | 'updatedAt'
 > & {
-  relatedOrder?: OrderRecordForList
+  relatedOrder?: { id: string }
 }

--- a/packages/tv-ad-admin-next/types/order.ts
+++ b/packages/tv-ad-admin-next/types/order.ts
@@ -4,7 +4,8 @@ export type OrderRecord = {
   id: string
   orderNumber: string
   name: string
-  schedule: string
+  scheduleStartDate: string
+  scheduleEndDate: string
   state: OrderState
   relatedOrder?: OrderRecord
   createdAt: string
@@ -17,7 +18,8 @@ export type OrderRecordForList = Pick<
   | 'orderNumber'
   | 'name'
   | 'state'
-  | 'schedule'
+  | 'scheduleStartDate'
+  | 'scheduleEndDate'
   | 'createdAt'
   | 'updatedAt'
 > & {

--- a/packages/tv-ad-admin-next/types/order.ts
+++ b/packages/tv-ad-admin-next/types/order.ts
@@ -1,11 +1,13 @@
 import { type OrderState } from '@/constants'
 
 export type OrderRecord = {
-  id: string
+  id: number
   orderNumber: string
-  name: string
-  scheduleStartDate: string
-  scheduleEndDate: string
+  name: string | null
+  scheduleStartDate: Date | null
+  scheduleEndDate: Date | null
+  scheduleStartDateString?: string | null
+  scheduleEndDateString?: string | null
   state: OrderState
   relatedOrder?: OrderRecord
   createdAt: string
@@ -20,6 +22,8 @@ export type OrderRecordForList = Pick<
   | 'state'
   | 'scheduleStartDate'
   | 'scheduleEndDate'
+  | 'scheduleStartDateString'
+  | 'scheduleEndDateString'
   | 'createdAt'
   | 'updatedAt'
 > & {

--- a/packages/tv-ad-admin-next/utils/order-grouping.ts
+++ b/packages/tv-ad-admin-next/utils/order-grouping.ts
@@ -66,22 +66,26 @@ export function groupOrders(
 
       const formattedChain = chain.map((order) => ({
         ...order,
-        updatedAt: order.updatedAt
-          ? formatTaiwanDate(order.updatedAt)
-          : order.createdAt
-            ? formatTaiwanDate(order.createdAt)
-            : '',
-        createdAt: formatTaiwanDate(order.createdAt),
+        createdAt: order.createdAt ? formatTaiwanDate(order.createdAt) : '',
+        updatedAt: order.updatedAt ? formatTaiwanDate(order.updatedAt) : '',
       }))
 
       const rootOrder = formattedChain[0]
       const childOrders = formattedChain.slice(1)
 
-      // 子訂單按時間從舊到新排序
+      // 子訂單排序：非「已轉移」的排在前面，全部按 createdAt 從新到舊
       childOrders.sort((a, b) => {
-        const dateA = a.updatedAt || a.createdAt || ''
-        const dateB = b.updatedAt || b.createdAt || ''
-        return new Date(dateA).getTime() - new Date(dateB).getTime()
+        const isTransferredA = a.state === 'transferred'
+        const isTransferredB = b.state === 'transferred'
+
+        // 非「已轉移」的排在前面
+        if (isTransferredA && !isTransferredB) return 1
+        if (!isTransferredA && isTransferredB) return -1
+
+        // 其餘按 createdAt 從新到舊排序
+        const dateA = a.createdAt ?? ''
+        const dateB = b.createdAt ?? ''
+        return new Date(dateB).getTime() - new Date(dateA).getTime()
       })
 
       const sortedChain = [rootOrder, ...childOrders]
@@ -89,12 +93,12 @@ export function groupOrders(
     }
   }
 
-  // 按群組中最新的訂單時間從新到舊排序
+  // 按群組中第一筆訂單的 updatedAt 從新到舊排序
   groupedOrders.sort((a, b) => {
-    const latestA = a[a.length - 1]
-    const latestB = b[b.length - 1]
-    const dateA = latestA.updatedAt || latestA.createdAt || ''
-    const dateB = latestB.updatedAt || latestB.createdAt || ''
+    const firstA = a[0]
+    const firstB = b[0]
+    const dateA = firstA.updatedAt ?? ''
+    const dateB = firstB.updatedAt ?? ''
     return new Date(dateB).getTime() - new Date(dateA).getTime()
   })
 

--- a/packages/tv-ad-admin-next/utils/order-grouping.ts
+++ b/packages/tv-ad-admin-next/utils/order-grouping.ts
@@ -41,7 +41,8 @@ export function groupOrders(
 
     chain.push(order)
     processed[order.id] = true
-    const children = parentMap.get(order.id) || []
+    const children =
+      parentMap.get(order.id.toString()) || ([] as OrderRecordForList[])
 
     for (const child of children) {
       if (!processed[child.id]) {


### PR DESCRIPTION
## 功能
- 訂單列表顯示
- 新增欄位顯示（訂單編號、名稱、排播日期）
- 移除 hardcore「未命名」、「未排播」，使用真時資料
- 調整訂單排序
  - 群組內：非「已轉移」優先，按 createdAt 降序
  - 群組間：依第一筆訂單的 updatedAt 降序