### PR TITLE
chore(husky): add pre-push hook to run TypeScript checks only on changed packages

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+echo "Running ESLint & Prettier (lint-staged)..."
 npx lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,47 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+echo "Determining changed packages for this push..."
+
+# Read information provided by Git pre-push hook from STDIN.
+# Format: <local_ref> <local_sha> <remote_ref> <remote_sha>
+read local_ref local_sha remote_ref remote_sha
+
+# Detect base commit from remote branch — works even if local and remote names differ
+if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
+  echo "New branch detected. Using the previous local commit as the base for comparison."
+  BASE_COMMIT="HEAD~1"
+else
+  # Otherwise, compare against the remote branch’s latest commit.
+  BASE_COMMIT="$remote_sha"
+fi
+
+# Collect all changed files between the remote and local commits.
+CHANGED_FILES=$(git diff --name-only "$BASE_COMMIT" "$local_sha")
+
+# Filter only files located under the 'packages/' directory and extract unique package names.
+CHANGED_PACKAGES=$(echo "$CHANGED_FILES" | grep '^packages/' | cut -d'/' -f2 | sort -u)
+
+# If no packages were modified, skip the type check.
+if [ -z "$CHANGED_PACKAGES" ]; then
+  echo "No package changes detected. Skipping TypeScript check."
+  exit 0
+fi
+
+# Loop through all changed packages and run TypeScript checks individually.
+for pkg in $CHANGED_PACKAGES; do
+  PKG_PATH="packages/$pkg"
+
+  # Only check packages that have a tsconfig.json file.
+  if [ -d "$PKG_PATH" ] && [ -f "$PKG_PATH/tsconfig.json" ]; then
+    echo "Running TypeScript check for $PKG_PATH..."
+    (cd "$PKG_PATH" && yarn tsc --noEmit) || {
+      echo "Type check failed in $PKG_PATH"
+      exit 1
+    }
+  else
+    echo "Skipping $PKG_PATH (no tsconfig.json found)."
+  fi
+done
+
+echo "All TypeScript checks completed successfully."


### PR DESCRIPTION
Added a Husky `pre-push` hook that automatically runs TypeScript checks only for modified packages, optimizing CI efficiency and preventing type errors before pushing.  

## Additions  
- Added `.husky/pre-push` script  
  - Detects changed packages by comparing local and remote commits  
  - Runs `yarn tsc --noEmit` only on packages containing `tsconfig.json`  
  - Skips unchanged or non-TypeScript packages  

## Removals  
- N/A  

## Changes  
- Updated `.husky/pre-commit` to ensure ESLint & Prettier checks remain intact  

## Testing  
- Created new branch and verified pre-push hook triggers only when changes occur under `packages/`  
- Tested with multiple package updates and confirmed individual type-check execution  
- Verified skipping behavior when no relevant changes exist  

## Screenshots  
- N/A  

## Todos  
- N/A  

## Task Links  
- N/A  
