### PR TITLE
feat: add filtering to order list page

### DIFF
--- a/packages/tv-ad-admin-next/app/list/page.tsx
+++ b/packages/tv-ad-admin-next/app/list/page.tsx
@@ -39,7 +39,9 @@ function ListContent() {
       }
     }
     fetchOrders()
+  }, [])
 
+  useEffect(() => {
     const state = searchParams.get('state') || 'all'
     const keyword = searchParams.get('keyword') || ''
     setOrderState(state as OrderState | 'all')
@@ -64,7 +66,7 @@ function ListContent() {
       })
     }
     return filtered
-  }, [orderState, searchKeyword])
+  }, [orders, orderState, searchKeyword])
 
   const handleViewOrder = (orderNumber: string) => {
     router.push(`/order/${orderNumber}`)

--- a/packages/tv-ad-admin-next/app/list/page.tsx
+++ b/packages/tv-ad-admin-next/app/list/page.tsx
@@ -2,7 +2,7 @@
 
 import { Suspense, useState, useEffect, useMemo } from 'react'
 
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 
 import { OrderTable } from '@/components/list/order-table'
 import { SearchAndFilter } from '@/components/list/search-and-filter'
@@ -14,6 +14,7 @@ import { groupOrders } from '@/utils/order-grouping'
 
 function ListContent() {
   const router = useRouter()
+  const searchParams = useSearchParams()
   const [searchKeyword, setSearchKeyword] = useState('')
   const [orderState, setOrderState] = useState<OrderState | 'all'>('all')
   const [orders, setOrders] = useState<OrderRecordForList[][]>([])
@@ -38,14 +39,43 @@ function ListContent() {
       }
     }
     fetchOrders()
-  }, [])
+
+    const state = searchParams.get('state') || 'all'
+    const keyword = searchParams.get('keyword') || ''
+    setOrderState(state as OrderState | 'all')
+    setSearchKeyword(keyword)
+  }, [searchParams])
+
+  const renderedOrders = useMemo(() => {
+    let filtered = orders
+    if (orderState !== 'all') {
+      filtered = filtered.filter((order) => {
+        return order.some((o) => o.state === orderState)
+      })
+    }
+    if (searchKeyword) {
+      const keyword = searchKeyword.toLowerCase()
+      filtered = filtered.filter((order) => {
+        return order.some(
+          (o) =>
+            (o.name?.toLowerCase()?.includes(keyword) ?? false) ||
+            (o.orderNumber?.toLowerCase()?.includes(keyword) ?? false)
+        )
+      })
+    }
+
+    return filtered
+  }, [orders, orderState, searchKeyword])
 
   const handleViewOrder = (orderNumber: string) => {
     router.push(`/order/${orderNumber}`)
   }
 
   // 使用 memo 避免重複計算訂單總數
-  const totalOrders = useMemo(() => orders.flat().length, [orders])
+  const totalOrders = useMemo(
+    () => renderedOrders.flat().length,
+    [renderedOrders]
+  )
 
   return (
     <>
@@ -68,7 +98,7 @@ function ListContent() {
           ) : !totalOrders ? (
             <div className="py-8 text-center text-gray-6">沒有訂單資料</div>
           ) : (
-            <OrderTable orders={orders} onViewOrder={handleViewOrder} />
+            <OrderTable orders={renderedOrders} onViewOrder={handleViewOrder} />
           )}
         </div>
       </PageMain>

--- a/packages/tv-ad-admin-next/app/list/page.tsx
+++ b/packages/tv-ad-admin-next/app/list/page.tsx
@@ -47,7 +47,7 @@ function ListContent() {
   }, [searchParams])
 
   const renderedOrders = useMemo(() => {
-    let filtered = orders
+    let filtered = [...orders]
     if (orderState !== 'all') {
       filtered = filtered.filter((order) => {
         return order.some((o) => o.state === orderState)
@@ -63,9 +63,8 @@ function ListContent() {
         )
       })
     }
-
     return filtered
-  }, [orders, orderState, searchKeyword])
+  }, [orderState, searchKeyword])
 
   const handleViewOrder = (orderNumber: string) => {
     router.push(`/order/${orderNumber}`)

--- a/packages/tv-ad-admin-next/components/list/order-row.tsx
+++ b/packages/tv-ad-admin-next/components/list/order-row.tsx
@@ -25,7 +25,6 @@ export function OrderRow({
     scheduleStartDateString,
     scheduleEndDateString,
   } = order
-  console.log(order)
   const rowContent = [
     {
       key: 'number',


### PR DESCRIPTION
## 描述
- 因為 dashboard 有需求，可以在網址使用 `state` 和 `keyword` filter 要 render 的 order。

## 參考資料
- [figma](https://www.figma.com/design/9HfZIuqJ1wi84NbVzhe31P/202509_%E9%8F%A1%E6%96%B0%E8%81%9E_%E5%80%8B%E4%BA%BA%E5%BB%A3%E5%91%8A?node-id=2056-2047&t=cEcTZKVhcSNJvkX8-0)