### PR TITLE
feat: add authentication and member filtering to order APIs

### DIFF
--- a/packages/tv-ad-admin-next/app/api/list/orders/route.ts
+++ b/packages/tv-ad-admin-next/app/api/list/orders/route.ts
@@ -3,16 +3,27 @@ import { NextResponse } from 'next/server'
 import { getOrdersQuery } from '@/graphql/queries/orders'
 import { type OrderRecordForList } from '@/graphql/queries/orders'
 import { getClient } from '@/utils/apollo-client'
+import { getCurrentUser } from '@/utils/auth'
 import { formatTaiwanDate } from '@/utils/date'
 import { createErrorLogger } from '@/utils/error-handler'
 
 export async function GET() {
+  const user = await getCurrentUser()
+  if (!user || !user.memberId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
   try {
     const client = getClient()
     const { data } = await client.query<{ orders: OrderRecordForList[] }>({
       query: getOrdersQuery,
       variables: {
-        where: {},
+        where: {
+          member: {
+            id: {
+              equals: user.memberId,
+            },
+          },
+        },
         orderBy: [{ updatedAt: 'desc' }],
       },
     })

--- a/packages/tv-ad-admin-next/app/api/order/[orderNumber]/route.ts
+++ b/packages/tv-ad-admin-next/app/api/order/[orderNumber]/route.ts
@@ -3,14 +3,20 @@ import { NextResponse } from 'next/server'
 import { getOrdersByOrderNumberQuery } from '@/graphql/queries/orders'
 import { type OrderRecordForOrderNumber } from '@/graphql/queries/orders'
 import { getClient } from '@/utils/apollo-client'
+import { getCurrentUser } from '@/utils/auth'
 import { formatTaiwanDate } from '@/utils/date'
 import { createErrorLogger } from '@/utils/error-handler'
 
 export async function GET(
-  request: Request,
+  _req: Request,
   { params }: { params: { orderNumber: string } }
 ) {
-  const orderNumber = params.orderNumber
+  const { orderNumber } = params
+  const user = await getCurrentUser()
+
+  if (!user || !user.memberId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
 
   if (!orderNumber) {
     return NextResponse.json(
@@ -29,6 +35,11 @@ export async function GET(
         where: {
           orderNumber: {
             equals: orderNumber,
+          },
+          member: {
+            id: {
+              equals: user.memberId,
+            },
           },
         },
       },


### PR DESCRIPTION
## 描述
- 在 list 和 order detail 時，只能拿到自己的資料。
- 沒有登入則會回傳 401。

## 請求確認
這樣 `list`、`dashboard` 和 `order` 頁面就算全部完成了。