### PR TITLE
feat: implement order confirmation with loading spinner

### DIFF
--- a/packages/tv-ad-admin-next/app/api/order/[orderNumber]/confirm/route.ts
+++ b/packages/tv-ad-admin-next/app/api/order/[orderNumber]/confirm/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { ORDER_STATE } from '@/constants'
+import { updateOrderStateMutation } from '@/graphql/mutations/orders'
+import { getClient } from '@/utils/apollo-client'
+import { createErrorLogger } from '@/utils/error-handler'
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { orderNumber?: string } }
+) {
+  const { orderNumber } = params ?? {}
+
+  if (!orderNumber) {
+    return NextResponse.json(
+      { error: 'Order number is required' },
+      { status: 400 }
+    )
+  }
+
+  try {
+    const client = getClient()
+    const { data, errors } = await client.mutate({
+      mutation: updateOrderStateMutation,
+      variables: {
+        where: {
+          orderNumber: orderNumber,
+        },
+        data: {
+          state: ORDER_STATE.PENDING_SCHEDULE,
+        },
+      },
+      errorPolicy: 'all',
+    })
+
+    if (errors && errors.length > 0) {
+      const errorMessage = errors
+        .map((e: { message: string }) => e.message)
+        .join(', ')
+      createErrorLogger(`Failed to confirm order: ${orderNumber}`)(
+        new Error(`GraphQL errors: ${errorMessage}`)
+      )
+
+      return NextResponse.json(
+        { error: `Failed to confirm order: ${errorMessage}` },
+        { status: 500 }
+      )
+    }
+
+    return NextResponse.json({
+      success: true,
+      order: data?.updateOrder,
+    })
+  } catch (error) {
+    createErrorLogger(`Failed to confirm order: ${orderNumber}`)(error)
+
+    return NextResponse.json(
+      { error: `Failed to confirm order: ${orderNumber}` },
+      { status: 500 }
+    )
+  }
+}

--- a/packages/tv-ad-admin-next/app/api/order/[orderNumber]/confirm/route.ts
+++ b/packages/tv-ad-admin-next/app/api/order/[orderNumber]/confirm/route.ts
@@ -32,10 +32,10 @@ export async function POST(
         },
         data: {
           state: ORDER_STATE.PENDING_SCHEDULE,
-        },
-        member: {
-          id: {
-            equals: user.memberId,
+          member: {
+            id: {
+              equals: user.memberId,
+            },
           },
         },
       },

--- a/packages/tv-ad-admin-next/app/api/order/[orderNumber]/confirm/route.ts
+++ b/packages/tv-ad-admin-next/app/api/order/[orderNumber]/confirm/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { ORDER_STATE } from '@/constants'
 import { updateOrderStateMutation } from '@/graphql/mutations/orders'
 import { getClient } from '@/utils/apollo-client'
+import { getCurrentUser } from '@/utils/auth'
 import { createErrorLogger } from '@/utils/error-handler'
 
 export async function POST(
@@ -10,7 +11,10 @@ export async function POST(
   { params }: { params: { orderNumber?: string } }
 ) {
   const { orderNumber } = params ?? {}
-
+  const user = await getCurrentUser()
+  if (!user || !user.memberId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
   if (!orderNumber) {
     return NextResponse.json(
       { error: 'Order number is required' },
@@ -28,6 +32,11 @@ export async function POST(
         },
         data: {
           state: ORDER_STATE.PENDING_SCHEDULE,
+        },
+        member: {
+          id: {
+            equals: user.memberId,
+          },
         },
       },
       errorPolicy: 'all',

--- a/packages/tv-ad-admin-next/app/api/order/[orderNumber]/schedule/route.ts
+++ b/packages/tv-ad-admin-next/app/api/order/[orderNumber]/schedule/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { updateOrderScheduleMutation } from '@/graphql/mutations/orders'
 import { getClient } from '@/utils/apollo-client'
+import { getCurrentUser } from '@/utils/auth'
 import { createErrorLogger } from '@/utils/error-handler'
 
 export async function POST(
@@ -10,7 +11,10 @@ export async function POST(
   { params }: { params: { orderNumber?: string } }
 ) {
   const { orderNumber } = params ?? {}
-
+  const user = await getCurrentUser()
+  if (!user || !user.memberId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
   if (!orderNumber) {
     return NextResponse.json(
       { error: 'Order number is required' },
@@ -35,6 +39,11 @@ export async function POST(
       variables: {
         where: {
           orderNumber: orderNumber,
+          member: {
+            id: {
+              equals: user.memberId,
+            },
+          },
         },
         data: {
           scheduleStartDate: parseISO(scheduleStartDate),

--- a/packages/tv-ad-admin-next/app/order/[orderNumber]/page.tsx
+++ b/packages/tv-ad-admin-next/app/order/[orderNumber]/page.tsx
@@ -9,6 +9,7 @@ import { OrderDetails } from '@/components/order/order-details'
 import { OrderNotFound } from '@/components/order/order-not-found'
 import { OrderPreview } from '@/components/order/order-preview'
 import { OrderState as OrderStateComponent } from '@/components/order/order-state'
+import LoadingSpinner from '@/components/shared/loading-spinner'
 import PageHeader from '@/components/shared/page-header'
 import PageMain from '@/components/shared/page-main'
 import { ORDER_STATE_CONFIG, ORDER_STYLES } from '@/constants'
@@ -74,7 +75,11 @@ export default function OrderPage() {
               {order && <OrderStateComponent order={order} />}
             </div>
             {error && <div className="text-red-500">{error}</div>}
-            {isLoading && <div className="text-gray-500">載入中...</div>}
+            {isLoading && (
+              <div className="flex min-h-[400px] items-center justify-center">
+                <LoadingSpinner />
+              </div>
+            )}
             {!error && !isLoading && !order && (
               <OrderNotFound orderId={orderNumber} />
             )}

--- a/packages/tv-ad-admin-next/components/order/order-actions.tsx
+++ b/packages/tv-ad-admin-next/components/order/order-actions.tsx
@@ -3,6 +3,7 @@ import { useState, useMemo } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 
+import LoadingSpinner from '@/components/shared/loading-spinner'
 import { Button } from '@/components/ui/button'
 import { ORDER_STATE } from '@/constants'
 import { type OrderRecordForOrderNumber } from '@/graphql/queries/orders'
@@ -154,11 +155,28 @@ export function OrderActions({ order, className = '' }: OrderActionsProps) {
     setIsConfirming(true)
 
     try {
-      await new Promise((resolve) => setTimeout(resolve, 5000))
-      // TODO: 確認完成後，進入下一個階段
-      alert('我還沒做！請提醒1軒')
+      const response = await fetch(`/api/order/${order.orderNumber}/confirm`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const data = await response.json()
+
+      if (!response.ok || !data.success) {
+        throw new Error(data.error || '確認失敗')
+      }
+      window.location.reload()
     } catch (error) {
       console.error('確認失敗:', error)
+      alert(
+        error instanceof Error
+          ? `確認失敗: ${error.message}`
+          : '確認失敗，請稍後再試'
+      )
+    } finally {
+      setIsConfirming(false)
     }
   }
 
@@ -175,7 +193,8 @@ export function OrderActions({ order, className = '' }: OrderActionsProps) {
   }, [order.state])
 
   return (
-    <section className={`${styles.container} ${className}`}>
+    <section className={`${styles.container} ${className} relative`}>
+      {isConfirming && <LoadingSpinner message="確認中..." overlay />}
       <h5 className={styles.title}>訂單操作</h5>
       <div className={styles.buttonContainer}>
         {actionContent.buttonText && (

--- a/packages/tv-ad-admin-next/components/shared/loading-spinner.tsx
+++ b/packages/tv-ad-admin-next/components/shared/loading-spinner.tsx
@@ -1,0 +1,40 @@
+type LoadingSpinnerProps = {
+  message?: string
+  className?: string
+  size?: 'sm' | 'md' | 'lg'
+  overlay?: boolean
+}
+
+const sizeMap = {
+  sm: 'size-6',
+  md: 'size-8',
+  lg: 'size-12',
+}
+
+export default function LoadingSpinner({
+  message = '載入中...',
+  className = '',
+  size = 'md',
+  overlay = false,
+}: LoadingSpinnerProps) {
+  const spinnerSize = sizeMap[size]
+
+  const content = (
+    <div className={`flex flex-col items-center gap-3 ${className}`}>
+      <div
+        className={`${spinnerSize} animate-spin rounded-full border-4 border-gray-3 border-t-blue-6`}
+      />
+      {message && <p className="text-sm text-gray-7">{message}</p>}
+    </div>
+  )
+
+  if (overlay) {
+    return (
+      <div className="absolute inset-0 z-10 flex items-center justify-center rounded-lg bg-white/80 backdrop-blur-sm">
+        {content}
+      </div>
+    )
+  }
+
+  return content
+}

--- a/packages/tv-ad-admin-next/graphql/mutations/orders.ts
+++ b/packages/tv-ad-admin-next/graphql/mutations/orders.ts
@@ -13,3 +13,15 @@ export const updateOrderScheduleMutation = gql`
     }
   }
 `
+
+export const updateOrderStateMutation = gql`
+  mutation updateOrderState(
+    $where: OrderWhereUniqueInput!
+    $data: OrderUpdateInput!
+  ) {
+    updateOrder(where: $where, data: $data) {
+      id
+      state
+    }
+  }
+`


### PR DESCRIPTION
## 功能說明
- 實作訂單確認功能，當使用者點擊「確認」按鈕後，會將訂單狀態從「待確認」更新為「待排播」，並顯示載入動畫。
- 將「載入中」抽出成為 component，以後可以在多個地方共用。
- 按下確認鍵 > useEffect 觸發 api > 確認狀態和使用者權限 > ok 的話就重新整理。