### PR TITLE
refactor: update order state values and implement dynamic state transitions

### DIFF
--- a/packages/tv-ad-admin-next/app/api/order/[orderNumber]/confirm/route.ts
+++ b/packages/tv-ad-admin-next/app/api/order/[orderNumber]/confirm/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-import { ORDER_STATE } from '@/constants'
+import { getNextState, type OrderState } from '@/constants'
 import { updateOrderStateMutation } from '@/graphql/mutations/orders'
+import { getOrdersByOrderNumberQuery } from '@/graphql/queries/orders'
 import { getClient } from '@/utils/apollo-client'
 import { getCurrentUser } from '@/utils/auth'
 import { createErrorLogger } from '@/utils/error-handler'
@@ -24,6 +25,38 @@ export async function POST(
 
   try {
     const client = getClient()
+
+    // 先獲取當前訂單狀態
+    const { data: orderData } = await client.query({
+      query: getOrdersByOrderNumberQuery,
+      variables: {
+        where: {
+          orderNumber: {
+            equals: orderNumber,
+          },
+          member: {
+            id: {
+              equals: user.memberId,
+            },
+          },
+        },
+      },
+    })
+
+    const currentOrder = orderData?.orders?.[0]
+    if (!currentOrder) {
+      return NextResponse.json({ error: 'Order not found' }, { status: 404 })
+    }
+
+    // 根據 flow 獲取下一個狀態
+    const nextState = getNextState(currentOrder.state as OrderState)
+    if (!nextState) {
+      return NextResponse.json(
+        { error: 'Cannot determine next state for current order state' },
+        { status: 400 }
+      )
+    }
+
     const { data, errors } = await client.mutate({
       mutation: updateOrderStateMutation,
       variables: {
@@ -31,7 +64,7 @@ export async function POST(
           orderNumber: orderNumber,
         },
         data: {
-          state: ORDER_STATE.PENDING_SCHEDULE,
+          state: nextState,
           member: {
             id: {
               equals: user.memberId,

--- a/packages/tv-ad-admin-next/app/api/order/[orderNumber]/schedule/route.ts
+++ b/packages/tv-ad-admin-next/app/api/order/[orderNumber]/schedule/route.ts
@@ -1,7 +1,7 @@
 import { parseISO } from 'date-fns'
 import { NextRequest, NextResponse } from 'next/server'
 
-import { ORDER_STATE } from '@/constants/state/orderState'
+import { getNextState, ORDER_STATE } from '@/constants/state/orderState'
 import { updateOrderScheduleMutation } from '@/graphql/mutations/orders'
 import { getOrderScheduleQuery } from '@/graphql/queries/orders'
 import { getClient } from '@/utils/apollo-client'
@@ -119,6 +119,17 @@ export async function POST(
     }
 
     const client = getClient()
+
+    // 先獲取當前訂單狀態（已在 where 條件中確認是 PENDING_BROADCAST_DATE）
+    // 根據 flow 獲取下一個狀態
+    const nextState = getNextState(ORDER_STATE.PENDING_BROADCAST_DATE)
+    if (!nextState) {
+      return NextResponse.json(
+        { error: 'Cannot determine next state for current order state' },
+        { status: 400 }
+      )
+    }
+
     const { data, errors } = await client.mutate({
       mutation: updateOrderScheduleMutation,
       variables: {
@@ -138,8 +149,7 @@ export async function POST(
         data: {
           scheduleStartDate: parseISO(scheduleStartDate),
           scheduleEndDate: parseISO(scheduleEndDate),
-          // 設定排播日期後，將狀態更新為「待確認」
-          state: ORDER_STATE.PENDING_CONFIRMATION,
+          state: nextState,
         },
       },
       errorPolicy: 'all',

--- a/packages/tv-ad-admin-next/components/order/progress-steps.tsx
+++ b/packages/tv-ad-admin-next/components/order/progress-steps.tsx
@@ -1,8 +1,8 @@
 import {
   OrderStateMap,
   PROGRESS_COLOR_RULES,
-  getStatesByRoute,
-  getCurrentRoute,
+  getStatesByFlow,
+  getCurrentFlow,
   ORDER_STATE,
   type OrderState,
 } from '@/constants'
@@ -50,20 +50,20 @@ export function ProgressSteps({
     )
   }
 
-  const currentRoute = getCurrentRoute(currentStatus)
-  const progressSteps = getStatesByRoute(currentRoute)
+  const currentFlow = getCurrentFlow(currentStatus)
+  const progressSteps = getStatesByFlow(currentFlow)
 
   const getStepStatus = (step: OrderState, index: number) => {
     const isActive = currentStatus === step
     const completedStyle = PROGRESS_COLOR_RULES.getCompletedStyle()
     const currentIndex = progressSteps.indexOf(currentStatus)
 
-    const isTransferredRoute = currentRoute === 'transferred'
-    const isCompleted = isTransferredRoute ? true : index < currentIndex
+    const isTransferredFlow = currentFlow === 'transferred'
+    const isCompleted = isTransferredFlow ? true : index < currentIndex
 
     return {
       isCompleted: isCompleted,
-      isActive: isActive && !isTransferredRoute,
+      isActive: isActive && !isTransferredFlow,
       style: completedStyle,
     }
   }

--- a/packages/tv-ad-admin-next/constants/state/orderState.ts
+++ b/packages/tv-ad-admin-next/constants/state/orderState.ts
@@ -26,14 +26,15 @@ export type StateRoute =
 export const ORDER_STATE = {
   PENDING_UPLOAD: 'paid',
   MATERIAL_UPLOADED: 'file_uploaded',
-  VIDEO_PRODUCTION: 'material_confirmed',
-  PENDING_CONFIRMATION: 'material_updated',
-  PENDING_SCHEDULE: 'produced',
-  BROADCASTED: 'video_confirmed',
-  MODIFICATION_REQUEST: 'scheduled',
+  VIDEO_PRODUCTION: 'video_wip',
+  PENDING_CONFIRMATION: 'to_be_confirmed',
+  PENDING_SCHEDULE: 'scheduled',
+  BROADCASTED: 'broadcasted',
+  MODIFICATION_REQUEST: 'modification_request',
   PENDING_QUOTE_CONFIRMATION: 'pending_quote_confirmation',
   TRANSFERRED: 'transferred',
   PENDING_BROADCAST_DATE: 'pending_broadcast_date',
+  DATE_RESET: 'date_reset',
   CANCELLED: 'cancelled',
 } as const
 
@@ -44,7 +45,7 @@ export const OrderStateMap = {
     progressColor: 'red',
   },
   [ORDER_STATE.MATERIAL_UPLOADED]: {
-    label: '素材已上傳',
+    label: '已上傳檔案',
     colors: COLOR_THEMES.label.yellow,
     progressColor: 'yellow',
   },
@@ -59,7 +60,7 @@ export const OrderStateMap = {
     progressColor: 'red',
   },
   [ORDER_STATE.PENDING_SCHEDULE]: {
-    label: '待排播',
+    label: '排播',
     colors: COLOR_THEMES.label.blue,
     progressColor: 'green',
   },
@@ -74,12 +75,12 @@ export const OrderStateMap = {
     progressColor: 'orange',
   },
   [ORDER_STATE.PENDING_QUOTE_CONFIRMATION]: {
-    label: '待確認修改報價',
+    label: '待加購修改',
     colors: COLOR_THEMES.label.red,
     progressColor: 'red',
   },
   [ORDER_STATE.TRANSFERRED]: {
-    label: '已轉移',
+    label: '已轉移至新訂單',
     colors: COLOR_THEMES.label.dark,
     progressColor: 'green',
   },
@@ -87,6 +88,11 @@ export const OrderStateMap = {
     label: '待設定排播日期',
     colors: COLOR_THEMES.label.red,
     progressColor: 'red',
+  },
+  [ORDER_STATE.DATE_RESET]: {
+    label: '已重新設定排播日期',
+    colors: COLOR_THEMES.label.yellow,
+    progressColor: 'yellow',
   },
   [ORDER_STATE.CANCELLED]: {
     label: '已作廢',
@@ -131,6 +137,7 @@ export const getStatesByRoute = (route: StateRoute): OrderState[] => {
       ORDER_STATE.MATERIAL_UPLOADED,
       ORDER_STATE.VIDEO_PRODUCTION,
       ORDER_STATE.PENDING_BROADCAST_DATE,
+      ORDER_STATE.DATE_RESET,
       ORDER_STATE.PENDING_CONFIRMATION,
       ORDER_STATE.PENDING_SCHEDULE,
       ORDER_STATE.BROADCASTED,
@@ -154,10 +161,30 @@ export const getCurrentRoute = (state: OrderState): StateRoute => {
   ) {
     return 'edit'
   }
-  if (state === ORDER_STATE.PENDING_BROADCAST_DATE) {
+  if (
+    state === ORDER_STATE.PENDING_BROADCAST_DATE ||
+    state === ORDER_STATE.DATE_RESET
+  ) {
     return 'setTime'
   }
   return 'normal'
+}
+
+/**
+ * 根據當前狀態獲取下一個狀態（根據 flow）
+ * @param currentState 當前狀態
+ * @returns 下一個狀態，如果已經是最後一個狀態或找不到則返回 null
+ */
+export const getNextState = (currentState: OrderState): OrderState | null => {
+  const route = getCurrentRoute(currentState)
+  const states = getStatesByRoute(route)
+  const currentIndex = states.indexOf(currentState)
+
+  if (currentIndex === -1 || currentIndex === states.length - 1) {
+    return null
+  }
+
+  return states[currentIndex + 1]
 }
 
 export const PROGRESS_COLOR_RULES = {

--- a/packages/tv-ad-admin-next/constants/state/orderState.ts
+++ b/packages/tv-ad-admin-next/constants/state/orderState.ts
@@ -1,28 +1,7 @@
 import { COLOR_THEMES } from './colors'
 
-export type StateRoute =
-  | 'normal'
-  | 'cancel'
-  | 'setTime'
-  | 'edit'
-  | 'transferred'
+export type StateFlow = 'normal' | 'cancel' | 'setTime' | 'edit' | 'transferred'
 
-// TODO: 跟後端的有些值對不上，可能還少一兩個 key
-// const orderStateOptions = [
-//   { label: '待上傳素材', value: 'paid' },
-//   { label: '已上傳檔案', value: 'file_uploaded' },
-//   { label: '已確認素材', value: 'material_confirmed' },
-//   { label: '素材更新', value: 'material_updated' },
-//   { label: '已製作', value: 'produced' },
-//   { label: '影片確認', value: 'video_confirmed' },
-//   { label: '排播', value: 'scheduled' },
-//   { label: '已播出', value: 'broadcasted' },
-//   { label: '提出修改要求', value: 'modification_request' }, 待修正
-//   { label: '待確認修改報價', value: 'pending_quote_confirmation' }, 已修正
-//   { label: '已轉交', value: 'transferred' },
-//   { label: '待排播', value: 'pending_broadcast_date' },
-//   { label: '已取消', value: 'cancelled' },
-// ]
 export const ORDER_STATE = {
   PENDING_UPLOAD: 'paid',
   MATERIAL_UPLOADED: 'file_uploaded',
@@ -103,39 +82,35 @@ export const OrderStateMap = {
 
 export type OrderState = keyof typeof OrderStateMap
 
-// 根據路線獲取狀態列表（按業務邏輯順序）
-export const getStatesByRoute = (route: StateRoute): OrderState[] => {
-  const routeOrderMap: Record<StateRoute, OrderState[]> = {
+const basicFlow = [
+  ORDER_STATE.PENDING_UPLOAD,
+  ORDER_STATE.MATERIAL_UPLOADED,
+  ORDER_STATE.VIDEO_PRODUCTION,
+  ORDER_STATE.PENDING_CONFIRMATION,
+]
+
+// 根據流程獲取狀態列表（按業務邏輯順序）
+export const getStatesByFlow = (flow: StateFlow): OrderState[] => {
+  const flowOrderMap: Record<StateFlow, OrderState[]> = {
     normal: [
-      ORDER_STATE.PENDING_UPLOAD,
-      ORDER_STATE.MATERIAL_UPLOADED,
-      ORDER_STATE.VIDEO_PRODUCTION,
-      ORDER_STATE.PENDING_CONFIRMATION,
+      ...basicFlow,
       ORDER_STATE.PENDING_SCHEDULE,
       ORDER_STATE.BROADCASTED,
     ],
     edit: [
-      ORDER_STATE.PENDING_UPLOAD,
-      ORDER_STATE.MATERIAL_UPLOADED,
-      ORDER_STATE.VIDEO_PRODUCTION,
-      ORDER_STATE.PENDING_CONFIRMATION,
+      ...basicFlow,
       ORDER_STATE.MODIFICATION_REQUEST,
       ORDER_STATE.PENDING_QUOTE_CONFIRMATION,
       ORDER_STATE.TRANSFERRED,
     ],
     transferred: [
-      ORDER_STATE.PENDING_UPLOAD,
-      ORDER_STATE.MATERIAL_UPLOADED,
-      ORDER_STATE.VIDEO_PRODUCTION,
-      ORDER_STATE.PENDING_CONFIRMATION,
+      ...basicFlow,
       ORDER_STATE.MODIFICATION_REQUEST,
       ORDER_STATE.PENDING_QUOTE_CONFIRMATION,
       ORDER_STATE.TRANSFERRED,
     ],
     setTime: [
-      ORDER_STATE.PENDING_UPLOAD,
-      ORDER_STATE.MATERIAL_UPLOADED,
-      ORDER_STATE.VIDEO_PRODUCTION,
+      ...basicFlow.slice(0, 3),
       ORDER_STATE.PENDING_BROADCAST_DATE,
       ORDER_STATE.DATE_RESET,
       ORDER_STATE.PENDING_CONFIRMATION,
@@ -145,10 +120,10 @@ export const getStatesByRoute = (route: StateRoute): OrderState[] => {
     cancel: [ORDER_STATE.CANCELLED],
   }
 
-  return routeOrderMap[route] || []
+  return flowOrderMap[flow] || []
 }
 
-export const getCurrentRoute = (state: OrderState): StateRoute => {
+export const getCurrentFlow = (state: OrderState): StateFlow => {
   if (state === ORDER_STATE.CANCELLED) {
     return 'cancel'
   }
@@ -176,8 +151,8 @@ export const getCurrentRoute = (state: OrderState): StateRoute => {
  * @returns 下一個狀態，如果已經是最後一個狀態或找不到則返回 null
  */
 export const getNextState = (currentState: OrderState): OrderState | null => {
-  const route = getCurrentRoute(currentState)
-  const states = getStatesByRoute(route)
+  const flow = getCurrentFlow(currentState)
+  const states = getStatesByFlow(flow)
   const currentIndex = states.indexOf(currentState)
 
   if (currentIndex === -1 || currentIndex === states.length - 1) {

--- a/packages/tv-ad-admin-next/utils/order-grouping.ts
+++ b/packages/tv-ad-admin-next/utils/order-grouping.ts
@@ -1,6 +1,6 @@
 import { formatTaiwanDate } from './date'
 
-import { OrderStateMap } from '@/constants'
+import { OrderStateMap, ORDER_STATE } from '@/constants'
 import {
   type OrderRecordForList,
   type OrderRecordForDashboard,
@@ -79,8 +79,8 @@ export function groupOrders(
 
       // 子訂單排序：非「已轉移」的排在前面，全部按 createdAt 從新到舊
       childOrders.sort((a, b) => {
-        const isTransferredA = a.state === 'transferred'
-        const isTransferredB = b.state === 'transferred'
+        const isTransferredA = a.state === ORDER_STATE.TRANSFERRED
+        const isTransferredB = b.state === ORDER_STATE.TRANSFERRED
 
         // 非「已轉移」的排在前面
         if (isTransferredA && !isTransferredB) return 1


### PR DESCRIPTION
## 描述
- 更新所有狀態的 `value`（對應 CMS State Label）
    - `order-grouping.ts`：將 hardcore 的 `'transferred'` 改為使用 `ORDER_STATE.TRANSFERRED`
- 更新所有狀態的 `label`（中文標籤）
- 新增 `DATE_RESET` 狀態（已重新設定排播日期）
- 新增 `getNextState()`，根據 flow 動態獲取下一個狀態，取代原本寫死的狀態
   - `confirm/route.ts`：確認訂單時，根據當前狀態動態獲取下一個狀態
   - `schedule/route.ts`：設定排播日期時，根據 flow 動態獲取下一個狀態

## 測試建議
- 確認不同狀態的訂單詳情頁面顯示正常
- 測試訂單確認功能，確認狀態轉換正確
- 測試排播日期設定功能，確認狀態轉換正確

## 參考資料
- [訂單狀態對應表](https://www.dropbox.com/scl/fi/wo5d9j5bpv3qjiej05dgt/.paper?rlkey=s07nr3cfg49mben5xqmc039p0&dl=0)