### PR TITLE
fix: remove story and external 320*480 ad

### DIFF
--- a/packages/mirror-tv-next/app/external/[slug]/layout.tsx
+++ b/packages/mirror-tv-next/app/external/[slug]/layout.tsx
@@ -50,7 +50,6 @@ export default function StoryPageLayout({
 
       <section className={styles.ads}>
         <GPTAd pageKey="story" adKey="MB_M1" />
-        <GPTAd pageKey="fs" adKey="MB_NEWS" />
         <GPTAd pageKey="all" adKey="PC_HD" />
       </section>
       <section className={styles.story}>

--- a/packages/mirror-tv-next/app/story/[slug]/layout.tsx
+++ b/packages/mirror-tv-next/app/story/[slug]/layout.tsx
@@ -50,7 +50,6 @@ export default function StoryPageLayout({
 
       <section className={styles.ads}>
         <GPTAd pageKey="story" adKey="MB_M1" />
-        <GPTAd pageKey="fs" adKey="MB_NEWS" />
         <GPTAd pageKey="all" adKey="PC_HD" />
       </section>
       <section className={styles.story}>


### PR DESCRIPTION
- ad: ` <GPTAd pageKey="fs" adKey="MB_NEWS" />`
- 文章頁－手機版第二個廣告版位移除 320*480
- asana link: [ticket](https://app.asana.com/1/614399484723017/project/1180545429058675/task/1211872412581484?focus=true)