### PR TITLE
feat: implement order grouping logic for upload page

### DIFF
--- a/packages/tv-ad-admin-next/components/upload/order-select-field.tsx
+++ b/packages/tv-ad-admin-next/components/upload/order-select-field.tsx
@@ -11,10 +11,11 @@ import {
   SelectItem,
   SelectValue,
 } from '@/components/ui/select'
-import { layout, ORDER_STATE } from '@/constants'
+import { layout } from '@/constants'
 import { OrderRecordForUploadQuery } from '@/graphql/queries/orders'
 import FileIcon from '@/public/icons/file.svg'
 import { cn } from '@/utils'
+import { groupOrdersForUpload } from '@/utils/order-grouping'
 
 type OrderSelectFieldProps = {
   orders: OrderRecordForUploadQuery[]
@@ -38,17 +39,12 @@ export default function OrderSelectField({
   const orderedSelectItems = useMemo(() => {
     const items: SelectGroupItem[] = []
 
-    const uploadOrders = orders.filter(
-      (o) => o.state === ORDER_STATE.PENDING_UPLOAD
-    )
-    const reuploadOrders = orders.filter(
-      (o) => o.state === ORDER_STATE.PENDING_QUOTE_CONFIRMATION
-    )
+    const { newOrders, reuploadOrders } = groupOrdersForUpload(orders)
 
-    if (uploadOrders.length > 0) {
+    if (newOrders.length > 0) {
       items.push({ type: 'label', label: '新訂單' })
       items.push(
-        ...uploadOrders.map((o) => ({ type: 'order' as const, order: o }))
+        ...newOrders.map((o) => ({ type: 'order' as const, order: o }))
       )
     }
 

--- a/packages/tv-ad-admin-next/graphql/queries/orders.ts
+++ b/packages/tv-ad-admin-next/graphql/queries/orders.ts
@@ -132,6 +132,8 @@ export type OrderRecordForUploadQuery = Pick<
   | 'image'
   | 'imageEditable'
   | 'state'
+  | 'price'
+  | 'modificationPrice'
 > & {
   orderNumber: string
 }
@@ -169,6 +171,8 @@ export const getOrdersForUpload = gql`
       }
       imageEditable
       state
+      price
+      modificationPrice
     }
   }
 `

--- a/packages/tv-ad-admin-next/types/order.ts
+++ b/packages/tv-ad-admin-next/types/order.ts
@@ -35,6 +35,7 @@ export type OrderSchema = {
 
   price?: number | null
   videoDuration?: number | null
+  modificationPrice?: number | null
 }
 
 export type MemberSchema = {

--- a/packages/tv-ad-admin-next/utils/order-grouping.ts
+++ b/packages/tv-ad-admin-next/utils/order-grouping.ts
@@ -4,6 +4,7 @@ import { OrderStateMap, ORDER_STATE } from '@/constants'
 import {
   type OrderRecordForList,
   type OrderRecordForDashboard,
+  type OrderRecordForUploadQuery,
 } from '@/graphql/queries/orders'
 
 type RelatedOrder = { id: string } | Array<{ id: string }>
@@ -124,4 +125,60 @@ export function getOrdersState(
     state: state as keyof typeof OrderStateMap,
     count: count,
   }))
+}
+
+/**
+  1. newOrders: 狀態為 PENDING_UPLOAD 且沒有 price 的訂單
+  2. reuploadOrders: 
+    - 狀態為 PENDING_QUOTE_CONFIRMATION
+    - 有其他「狀態為 PENDING_UPLOAD、且 price 與自身的 modificationPrice 一樣」的訂單，則放入 reuploadOrders，並將對應訂單的 orderNumber 記錄 canRelatedOrders
+ */
+export function groupOrdersForUpload(orders: OrderRecordForUploadQuery[]): {
+  newOrders: OrderRecordForUploadQuery[]
+  reuploadOrders: (OrderRecordForUploadQuery & {
+    canRelatedOrders: OrderRecordForUploadQuery['orderNumber'][]
+  })[]
+} {
+  const newOrders: OrderRecordForUploadQuery[] = []
+  const reuploadOrders: (OrderRecordForUploadQuery & {
+    canRelatedOrders: OrderRecordForUploadQuery['orderNumber'][]
+  })[] = []
+
+  const pendingUploadOrdersByPrice = new Map<
+    number | null,
+    OrderRecordForUploadQuery[]
+  >()
+
+  for (const order of orders) {
+    if (order.state === ORDER_STATE.PENDING_UPLOAD) {
+      if (!order.price) {
+        newOrders.push(order)
+      } else {
+        const price = order.price ?? null
+        if (!pendingUploadOrdersByPrice.has(price)) {
+          pendingUploadOrdersByPrice.set(price, [])
+        }
+        pendingUploadOrdersByPrice.get(price)!.push(order)
+      }
+    }
+  }
+
+  for (const order of orders) {
+    if (order.state === ORDER_STATE.PENDING_QUOTE_CONFIRMATION) {
+      const matchingOrders =
+        pendingUploadOrdersByPrice.get(order.modificationPrice ?? null) || []
+      if (matchingOrders.length) {
+        const canRelatedOrders = matchingOrders.map((o) => o.orderNumber)
+        reuploadOrders.push({
+          ...order,
+          canRelatedOrders,
+        })
+      }
+    }
+  }
+
+  return {
+    newOrders,
+    reuploadOrders,
+  }
 }


### PR DESCRIPTION
## PR 描述
- 在 `upload` 頁面將訂單分成「新訂單」和「待修改訂單」，並在待修改訂單中標示可以關聯的訂單編號。
   - `newOrders`：狀態為 `PENDING_UPLOAD` 且沒有 `price` 的訂單
   - `reuploadOrders`：狀態為 `PENDING_QUOTE_CONFIRMATION` 的訂單，且需有 `PENDING_UPLOAD` 訂單的 `price` 與其 `modificationPrice` 相同；匹配的訂單號會記錄在 `canRelatedOrders`。
- 新增 `price` 和 `modificationPrice` 於 `OrderRecordForUploadQuery` 中，並多 fetch。

## TODO
- 確認訂單價錢邏輯後，於 lilith 修改。
- 該 PR 通過後，要修改 mutate 邏輯。

## 參考資料
- [討論串](https://mirrormedia.slack.com/archives/C06NJC1CNRZ/p1762852315268209)