### PR TITLE
feat(edit-request): submit order update and trigger notify email (basic flow)

### DIFF
--- a/packages/tv-ad-admin-next/app/(edit)/edit-request/[orderNumber]/page.tsx
+++ b/packages/tv-ad-admin-next/app/(edit)/edit-request/[orderNumber]/page.tsx
@@ -55,6 +55,7 @@ export default function EditRequest({
 
   useEffect(() => {
     const fetchEditRequest = async () => {
+      // TODO: 待更新 loading 指示狀態
       if (!orderNumber) {
         router.push('/not-found/404')
         return
@@ -109,19 +110,8 @@ export default function EditRequest({
     if (Object.keys(newError).length > 0) return
 
     try {
-      const res = await fetch('/api/edit-request/order', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          state: orderData.state,
-          orderNumber: orderData.orderNumber,
-        }),
-      })
-
-      if (!res.ok) throw new Error(`Response status: ${res.status}`)
-
-      // TODO: 應該要有根據寄信成功/失敗來顯示狀態或是避免前一支 API state 切換
-      await fetch('/api/edit-request/send-notify-email', {
+      // Step 1: send email first
+      const emailRes = await fetch('/api/edit-request/send-notify-email', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -130,6 +120,22 @@ export default function EditRequest({
           details,
         }),
       })
+
+      if (!emailRes.ok) {
+        throw new Error(`Email failed: ${emailRes.status}`)
+      }
+
+      // Step 2: update state only if email succeeded
+      const updateRes = await fetch('/api/edit-request/order', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          state: orderData.state,
+          orderNumber: orderData.orderNumber,
+        }),
+      })
+
+      if (!updateRes.ok) throw new Error(`Response status: ${updateRes.status}`)
 
       setSubmitStatus('success')
     } catch (err) {

--- a/packages/tv-ad-admin-next/app/(edit)/edit-request/[orderNumber]/page.tsx
+++ b/packages/tv-ad-admin-next/app/(edit)/edit-request/[orderNumber]/page.tsx
@@ -20,6 +20,7 @@ import TriangleExclamationIcon from '@/public/icons/triangle-exclamation.svg'
 import { cn } from '@/utils'
 import { handleUnauthorized } from '@/utils/handle-unauthorized'
 
+
 const textareaStyle = [
   'w-full resize-none rounded-md bg-gray-2 p-3 placeholder:!text-text-tertiary placeholder:text-h6',
   layout.hoverBorder,
@@ -92,22 +93,38 @@ export default function EditRequest({
     fetchEditRequest()
   }, [router, orderNumber])
 
-  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
+
+    if (!orderData) {
+      setError({ reason: '訂單尚未載入完成' })
+      return
+    }
+
     const newError: typeof error = {}
     if (!reason.trim()) newError.reason = '請輸入修改原因'
     if (!details.trim()) newError.details = '請輸入修改詳情'
     setError(newError)
 
     if (Object.keys(newError).length > 0) return
-    // eslint-disable-next-line no-console
-    console.log({ reason, details })
 
-    // Demo alert to choose result
-    const isSuccess = window.confirm(
-      '是否要模擬「送出成功」？按「取消」則模擬失敗。'
-    )
-    setSubmitStatus(isSuccess ? 'success' : 'failure')
+    try {
+      const res = await fetch('/api/edit-request/order', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          state: orderData.state,
+          orderNumber: orderData.orderNumber,
+        }),
+      })
+
+      if (!res.ok) throw new Error(`Response status: ${res.status}`)
+      setSubmitStatus('success')
+    } catch (err) {
+      console.error('Failed to submit edit request:', err)
+      setSubmitStatus('failure')
+    }
   }
 
   if (submitStatus === 'success') {
@@ -129,7 +146,6 @@ export default function EditRequest({
       onSubmit={handleSubmit}
       submitButtonName="送出修改請求"
       orderData={orderData}
-      // submitStatus={submitStatus}
     >
       <LabeledField
         id={reasonId}

--- a/packages/tv-ad-admin-next/app/(edit)/edit-request/[orderNumber]/page.tsx
+++ b/packages/tv-ad-admin-next/app/(edit)/edit-request/[orderNumber]/page.tsx
@@ -93,7 +93,6 @@ export default function EditRequest({
     fetchEditRequest()
   }, [router, orderNumber])
 
-
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
 
@@ -120,6 +119,18 @@ export default function EditRequest({
       })
 
       if (!res.ok) throw new Error(`Response status: ${res.status}`)
+
+      // TODO: 應該要有根據寄信成功/失敗來顯示狀態或是避免前一支 API state 切換
+      await fetch('/api/edit-request/send-notify-email', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          orderNumber: orderData.orderNumber,
+          reason,
+          details,
+        }),
+      })
+
       setSubmitStatus('success')
     } catch (err) {
       console.error('Failed to submit edit request:', err)

--- a/packages/tv-ad-admin-next/app/api/edit-request/order/route.ts
+++ b/packages/tv-ad-admin-next/app/api/edit-request/order/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { getNextState, ORDER_STATE } from '@/constants/state/orderState'
+import { updateOrderEditRequestMutation } from '@/graphql/mutations/orders'
+import { getClient } from '@/utils/apollo-client'
+import { getCurrentUser } from '@/utils/auth'
+import { createErrorLogger } from '@/utils/error-handler'
+
+export async function POST(request: NextRequest) {
+  const client = getClient()
+
+  try {
+    const currentUser = await getCurrentUser()
+
+    if (!currentUser || !currentUser.userId || !currentUser.memberId) {
+      return NextResponse.json(
+        { error: 'Unauthorized or missing memberId.' },
+        { status: 401 }
+      )
+    }
+
+    const body = await request.json()
+    const { state: currentState, orderNumber } = body
+
+    if (!orderNumber) {
+      return NextResponse.json(
+        { error: 'Order number is required' },
+        { status: 400 }
+      )
+    }
+
+    if (!currentState) {
+      return NextResponse.json(
+        { error: 'Current state is required' },
+        { status: 400 }
+      )
+    }
+
+    if (currentState !== ORDER_STATE.PENDING_CONFIRMATION) {
+      return NextResponse.json(
+        { error: 'Invalid state for edit request' },
+        { status: 400 }
+      )
+    }
+
+    const nextState = getNextState(currentState)
+    if (!nextState) {
+      return NextResponse.json(
+        { error: 'No next state for current state' },
+        { status: 400 }
+      )
+    }
+
+    const { data, errors } = await client.mutate({
+      mutation: updateOrderEditRequestMutation,
+      variables: {
+        where: {
+          orderNumber,
+        },
+        data: { state: nextState },
+      },
+      errorPolicy: 'all',
+    })
+
+    if (errors?.length) {
+      const errorMsg = errors.map((e) => e.message).join(', ')
+      createErrorLogger(`Failed to submit edit request: ${orderNumber}`)(
+        new Error(`GraphQL errors: ${errorMsg}`)
+      )
+      return NextResponse.json(
+        { error: `Failed to submit edit request: ${errorMsg}` },
+        { status: 500 }
+      )
+    }
+
+    if (!data?.updateOrder) {
+      return NextResponse.json({ error: 'Order not found' }, { status: 404 })
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: 'edit-request order fetched successfully.',
+      data: data.updateOrder,
+    })
+  } catch (err) {
+    createErrorLogger('Unexpected POST error in edit-request route')(err)
+    return NextResponse.json(
+      { error: 'Internal server error.' },
+      { status: 500 }
+    )
+  }
+}

--- a/packages/tv-ad-admin-next/app/api/edit-request/send-notify-email/route.ts
+++ b/packages/tv-ad-admin-next/app/api/edit-request/send-notify-email/route.ts
@@ -25,6 +25,9 @@ export async function POST(req: NextRequest) {
     // Decide recipients
     const recipients = [currentUser.email]
 
+    //TODO: 小米
+    // 1. 目前只有寄信給使用者，未寄信給業務。
+    // 2. 應該要有根據寄信成功/失敗來顯示狀態或是避免下一個 API fetch CMS state 切換，目前寄信 API 的錯誤判別可能不夠完整
     await sendOrderEditRequestEmail(recipients, orderNumber, reason, details)
 
     return NextResponse.json({

--- a/packages/tv-ad-admin-next/app/api/edit-request/send-notify-email/route.ts
+++ b/packages/tv-ad-admin-next/app/api/edit-request/send-notify-email/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { getCurrentUser } from '@/utils/auth'
+import { sendOrderEditRequestEmail } from '@/utils/edit-request-email-sender'
+
+export async function POST(req: NextRequest) {
+  try {
+    const currentUser = await getCurrentUser()
+    if (!currentUser || !currentUser.email) {
+      return NextResponse.json(
+        { success: false, message: 'Unauthorized' },
+        { status: 401 }
+      )
+    }
+
+    const { orderNumber, reason, details } = await req.json()
+
+    if (!orderNumber || !reason || !details) {
+      return NextResponse.json(
+        { success: false, message: 'Missing required fields' },
+        { status: 400 }
+      )
+    }
+
+    // Decide recipients
+    const recipients = [currentUser.email]
+
+    await sendOrderEditRequestEmail(recipients, orderNumber, reason, details)
+
+    return NextResponse.json({
+      success: true,
+      message: 'Edit request email sent',
+    })
+  } catch (err) {
+    console.error('edit-request-email error:', err)
+    return NextResponse.json(
+      { success: false, message: 'Server error' },
+      { status: 500 }
+    )
+  }
+}

--- a/packages/tv-ad-admin-next/app/api/order/[orderNumber]/edit-request/route.ts
+++ b/packages/tv-ad-admin-next/app/api/order/[orderNumber]/edit-request/route.ts
@@ -11,10 +11,13 @@ export async function GET(
   { params }: { params: { orderNumber?: string } }
 ) {
   const { orderNumber } = params ?? {}
-  const user = await getCurrentUser()
+  const currentUser = await getCurrentUser()
 
-  if (!user || !user.userId || !user.memberId) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  if (!currentUser || !currentUser.userId || !currentUser.memberId) {
+    return NextResponse.json(
+      { error: 'Unauthorized or missing memberId.' },
+      { status: 401 }
+    )
   }
 
   if (!orderNumber) {
@@ -35,7 +38,7 @@ export async function GET(
           },
           member: {
             id: {
-              equals: user.memberId,
+              equals: currentUser.memberId,
             },
           },
           state: {
@@ -43,6 +46,7 @@ export async function GET(
           },
         },
       },
+      fetchPolicy: 'no-cache',
       errorPolicy: 'all',
     })
 

--- a/packages/tv-ad-admin-next/graphql/mutations/orders.ts
+++ b/packages/tv-ad-admin-next/graphql/mutations/orders.ts
@@ -14,6 +14,21 @@ export const updateOrderScheduleMutation = gql`
   }
 `
 
+export const updateOrderEditRequestMutation = gql`
+  mutation updateOrderEditRequest(
+    $where: OrderWhereUniqueInput!
+    $data: OrderUpdateInput!
+  ) {
+    updateOrder(where: $where, data: $data) {
+      member {
+        id
+      }
+      orderNumber
+      state
+    }
+  }
+`
+
 export const updateOrderStateMutation = gql`
   mutation updateOrderState(
     $where: OrderWhereUniqueInput!

--- a/packages/tv-ad-admin-next/utils/edit-request-email-sender.ts
+++ b/packages/tv-ad-admin-next/utils/edit-request-email-sender.ts
@@ -1,5 +1,7 @@
 import { GoogleAuth } from 'google-auth-library'
 
+//TODO: 小米，請你看後續如何調整~ 
+
 type EditRequestEmailPayload = {
   receiver: string[]
   subject: string

--- a/packages/tv-ad-admin-next/utils/edit-request-email-sender.ts
+++ b/packages/tv-ad-admin-next/utils/edit-request-email-sender.ts
@@ -1,0 +1,66 @@
+import { GoogleAuth } from 'google-auth-library'
+
+type EditRequestEmailPayload = {
+  receiver: string[]
+  subject: string
+  body: string
+}
+
+async function sendEmail(payload: EditRequestEmailPayload, category: string) {
+  const emailApiUrl = process.env.EMAIL_API_URL as string
+  try {
+    const auth = new GoogleAuth()
+    const client = await auth.getIdTokenClient(emailApiUrl)
+
+    await client.request({
+      url: emailApiUrl,
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      data: payload,
+      timeout: 10000,
+    })
+  } catch (error) {
+    console.error(`Error sending ${category} email:`, {
+      error: error instanceof Error ? error.message : String(error),
+      receiver: payload.receiver,
+    })
+  }
+}
+
+export async function sendOrderEditRequestEmail(
+  receiverEmails: string[],
+  orderNumber: string,
+  reason: string,
+  details: string
+) {
+  const subject = `鏡電視個人廣告系統 - 訂單修改請求 (${orderNumber})`
+
+  const body = `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+  <h2 style="margin-top: 0;">訂單修改請求通知</h2>
+  <p>以下訂單已收到使用者的修改請求：</p>
+  <p><strong>訂單編號：</strong> ${orderNumber}</p>
+  <hr style="border: none; border-top: 1px solid #e0e0e0; margin: 20px 0;" />
+  <p><strong>修改原因：</strong></p>
+  <p style="white-space: pre-wrap;">${reason}</p>
+  <p><strong>修改詳情：</strong></p>
+  <p style="white-space: pre-wrap;">${details}</p>
+  <hr style="border: none; border-top: 1px solid #e0e0e0; margin: 20px 0;" />
+  <p style="font-size: 12px; color: #999;">
+    此為系統自動發送通知信，請勿直接回覆。
+  </p>
+</body>
+</html>
+  `.trim()
+
+  await sendEmail(
+    { receiver: receiverEmails, subject, body },
+    'order-edit-request'
+  )
+}


### PR DESCRIPTION
Implemented edit request submission flow with backend integration and email notification handling.

## Additions  
- Added `/app/api/edit-request/order/route.ts` to handle order state update and validation  
- Added `/app/api/edit-request/send-notify-email/route.ts` for sending edit request notification emails  
- Created `utils/edit-request-email-sender.ts` to integrate GoogleAuth and EMAIL_API_URL for email sending  
- Added new GraphQL mutation `updateOrderEditRequestMutation` in `graphql/mutations/orders.ts`  
- Updated `page.tsx` to include async submit logic, API calls, and status management  

## Removals  
- Removed old mock confirmation alert logic from edit-request submit handler  

## Changes  
- Updated `/app/api/order/[orderNumber]/edit-request/route.ts` to improve authorization and state validation  
- Enhanced `handleSubmit` to sequentially call order update and email notification APIs  
- Introduced error handling for failed order or email requests  
- Adjusted layout hover styling usage in edit-request page  

## Testing  
- Verified submit flow updates order state correctly and triggers email endpoint  
- Confirmed success/failure UI state rendering  
- TODO: add explicit handling for email send failure to rollback or skip state transition  

## Screenshots  
- N/A  

## Todos  
- Add recipient list logic for notifying business team instead of only current user  
- Add retry or rollback mechanism if email sending fails  

## Task Links  
- N/A  
