### PR TITLE
feat(upload): add shadcn checkbox and simplify CustomInput, fix upload logic and merge conflicts  

### DIFF
--- a/packages/tv-ad-admin-next/app/upload/page.tsx
+++ b/packages/tv-ad-admin-next/app/upload/page.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { Suspense, useEffect, useMemo, useState } from 'react'
+import { Suspense, useEffect, useState } from 'react'
 
-import { useRouter, useSearchParams } from 'next/navigation'
+import { useRouter } from 'next/navigation'
 
 import SubmitResult from '@/components/shared/submit-result'
 import { Spinner } from '@/components/ui/spinner'
@@ -18,20 +18,9 @@ const pageTitle = '上傳廣告素材'
 function UploadContent() {
   const { submitStatus, setSubmitStatus } = useSubmitStatus()
   const router = useRouter()
-  const searchParams = useSearchParams()
 
   const [orders, setOrders] = useState<OrderRecordForUploadQuery[]>([])
   const [loading, setLoading] = useState(true)
-
-  const orderNumberFromQuery = searchParams.get('orderNumber')
-
-  const validOrderNumber = useMemo(() => {
-    if (!orderNumberFromQuery) return undefined
-    if (orders.length === 0) return undefined
-    return orders.some((o) => o.orderNumber === orderNumberFromQuery)
-      ? orderNumberFromQuery
-      : undefined
-  }, [orderNumberFromQuery, orders])
 
   useEffect(() => {
     const fetchOrders = async () => {
@@ -141,7 +130,6 @@ function UploadContent() {
       onSubmit={handleConfirmUpload}
       orders={orders}
       loading={loading}
-      initialOrderNumber={validOrderNumber}
     />
   )
 }

--- a/packages/tv-ad-admin-next/components/custom-ui/custom-input.tsx
+++ b/packages/tv-ad-admin-next/components/custom-ui/custom-input.tsx
@@ -7,25 +7,15 @@ import { Input as BaseInput } from '../ui/input'
 import { layout } from '@/constants'
 import { cn } from '@/utils'
 
+
 export type CustomInputProps = ComponentProps<'input'> & {
   error?: string
   errorMessage?: string
   icon?: ReactNode
-  limit?: number
 }
 
 const CustomInput = forwardRef<HTMLInputElement, CustomInputProps>(
-  (
-    { className, error, errorMessage, icon, limit, onChange, ...props },
-    ref
-  ) => {
-    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-      if (limit && e.target.value.length > limit) {
-        return
-      }
-      onChange?.(e)
-    }
-
+  ({ className, error, errorMessage, icon, ...props }, ref) => {
     return (
       <div className="relative">
         <BaseInput
@@ -47,8 +37,6 @@ const CustomInput = forwardRef<HTMLInputElement, CustomInputProps>(
             error && ['border border-red-7', 'focus:border-red-8'],
             className
           )}
-          maxLength={limit}
-          onChange={handleChange}
           {...props}
         />
         {icon && (

--- a/packages/tv-ad-admin-next/components/ui/checkbox.tsx
+++ b/packages/tv-ad-admin-next/components/ui/checkbox.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import * as React from 'react'
+
+import * as CheckboxPrimitive from '@radix-ui/react-checkbox'
+import { CheckIcon } from 'lucide-react'
+
+import { cn } from '@/utils/index'
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        'peer size-4 shrink-0 rounded-[3px] border border-gray-5 shadow-xs transition-shadow outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-gray-5 disabled:data-[state=checked]:border-gray-5 disabled:data-[state=checked]:text-white disabled:data-[state=checked]:bg-gray-5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:bg-input/30 dark:aria-invalid:ring-destructive/40 dark:data-[state=checked]:bg-primary',
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }
+

--- a/packages/tv-ad-admin-next/components/upload/upload-template.tsx
+++ b/packages/tv-ad-admin-next/components/upload/upload-template.tsx
@@ -1,12 +1,13 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 
 import { addDays, format, formatISO, parseISO, startOfToday } from 'date-fns'
 import { DateRange } from 'react-day-picker'
 
 import ImageUploadField from './image-upload-field'
 import OrderSelectField from './order-select-field'
+import { Checkbox } from '../ui/checkbox'
 
 import { CustomInput } from '@/components/custom-ui/custom-input'
 import { LabeledField } from '@/components/custom-ui/labeled-field'
@@ -49,7 +50,6 @@ type UploadTemplateProps = {
   onSubmit: (data: OrderRecordForUploadMutation) => void
   orders: OrderRecordForUploadQuery[]
   loading: boolean
-  initialOrderNumber?: string
 }
 
 const initialFormState: FormState = {
@@ -62,6 +62,7 @@ const initialFormState: FormState = {
 }
 
 // ===== Label / Input Element IDs =====
+const adUrgentLabelId = 'ad-urgent-label'
 const adNameLabelId = 'ad-name-label'
 const adText1LabelId = 'ad-text1-label'
 const adText2LabelId = 'ad-text2-label'
@@ -73,7 +74,6 @@ export default function UploadTemplate({
   onSubmit,
   orders,
   loading,
-  initialOrderNumber,
 }: UploadTemplateProps) {
   const [selectedOrder, setSelectedOrder] =
     useState<OrderRecordForUploadQuery | null>(null)
@@ -141,19 +141,6 @@ export default function UploadTemplate({
     })
   }
 
-  // Auto-select order from query parameter
-  useEffect(() => {
-    if (initialOrderNumber && !loading && orders.length > 0 && !selectedOrder) {
-      const orderToSelect = orders.find(
-        (o) => o.orderNumber === initialOrderNumber
-      )
-      if (orderToSelect) {
-        handleOrderSelect(initialOrderNumber)
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [initialOrderNumber, loading, orders, selectedOrder])
-
   function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
 
@@ -204,7 +191,9 @@ export default function UploadTemplate({
           scheduleEndDate: formatISO(adRange.to),
         }),
       ...(adImage && { image: { data: adImage.data } }),
-      ...(mode === 'reupload' && { isUrgent: formState.isUrgent }),
+      ...(selectedOrder?.state === ORDER_STATE.PENDING_QUOTE_CONFIRMATION && {
+        isUrgent: formState.isUrgent,
+      }),
     }
 
     // Build dialog preview data (for UI only)
@@ -218,7 +207,9 @@ export default function UploadTemplate({
         from: format(adRange!.from!, 'yyyy/MM/dd'),
         to: format(adRange!.to!, 'yyyy/MM/dd'),
       },
-      ...(mode === 'reupload' && { isUrgent: formState.isUrgent }),
+      ...(selectedOrder?.state === ORDER_STATE.PENDING_QUOTE_CONFIRMATION && {
+        isUrgent: formState.isUrgent,
+      }),
     }
 
     setPreviewData(dialogPreviewData)
@@ -243,34 +234,32 @@ export default function UploadTemplate({
                 error={errors.order}
                 onSelect={handleOrderSelect}
                 value={selectedOrder?.orderNumber}
-                disabled={!!initialOrderNumber}
               />
-
-              {!!selectedOrder && mode === 'reupload' && (
-                <div className="flex items-center gap-2">
-                  <input
-                    type="checkbox"
-                    id="isUrgent"
-                    checked={formState.isUrgent}
-                    onChange={(e) =>
-                      setFormState((prev) => ({
-                        ...prev,
-                        isUrgent: e.target.checked,
-                      }))
-                    }
-                    className="h-4 w-4 rounded border-gray-4 text-blue-6 focus:ring-2 focus:ring-blue-6 focus:ring-offset-2"
-                  />
-                  <label
-                    htmlFor="isUrgent"
-                    className="cursor-pointer text-sm font-medium text-text-primary"
-                  >
-                    這是急件訂單
-                  </label>
-                </div>
-              )}
 
               {!!selectedOrder && (
                 <>
+                  {/* 急件訂單 */}
+                  {mode === 'reupload' && (
+                    <div className="-mt-4 flex items-center gap-2">
+                      <Checkbox
+                        id={adUrgentLabelId}
+                        checked={formState.isUrgent}
+                        onCheckedChange={(value) =>
+                          setFormState((prev) => ({
+                            ...prev,
+                            isUrgent: Boolean(value),
+                          }))
+                        }
+                      />
+                      <label
+                        htmlFor={adUrgentLabelId}
+                        className="cursor-pointer text-sm font-medium text-text-primary"
+                      >
+                        這是急件訂單
+                      </label>
+                    </div>
+                  )}
+
                   {/* 廣告名稱 + 排播日期 */}
                   <div className="grid gap-8 md:grid-cols-2 md:gap-4">
                     <LabeledField
@@ -310,7 +299,7 @@ export default function UploadTemplate({
                   {/* 文字素材一、二 */}
                   <LabeledField
                     id={adText1LabelId}
-                    label="文字素材一 (10字內)"
+                    label="文字素材一 (50字內)"
                     labelIcon={<TextFormatIcon />}
                   >
                     <CustomInput
@@ -324,6 +313,7 @@ export default function UploadTemplate({
                           adText1: e.target.value,
                         }))
                       }
+                      maxLength={50}
                       error={errors.adText1}
                       errorMessage={errors.adText1}
                     />
@@ -331,7 +321,7 @@ export default function UploadTemplate({
 
                   <LabeledField
                     id={adText2LabelId}
-                    label="文字素材二 (10字內)"
+                    label="文字素材二 (50字內)"
                     labelIcon={<TextFormatIcon />}
                   >
                     <CustomInput
@@ -345,6 +335,7 @@ export default function UploadTemplate({
                           adText2: e.target.value,
                         }))
                       }
+                      maxLength={50}
                       error={errors.adText2}
                       errorMessage={errors.adText2}
                     />

--- a/packages/tv-ad-admin-next/package.json
+++ b/packages/tv-ad-admin-next/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.14.0",
+    "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-select": "^2.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1956,6 +1956,20 @@
   dependencies:
     "@radix-ui/react-primitive" "2.1.3"
 
+"@radix-ui/react-checkbox@^1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz#db45ca8a6d5c056a92f74edbb564acee05318b79"
+  integrity sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==
+  dependencies:
+    "@radix-ui/primitive" "1.1.3"
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-presence" "1.1.5"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-use-controllable-state" "1.2.2"
+    "@radix-ui/react-use-previous" "1.1.1"
+    "@radix-ui/react-use-size" "1.1.1"
+
 "@radix-ui/react-collection@1.1.7":
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-collection/-/react-collection-1.1.7.tgz#d05c25ca9ac4695cc19ba91f42f686e3ea2d9aec"


### PR DESCRIPTION
Introduced `Checkbox` from Shadcn for unified UI consistency, simplified input logic, and fixed upload flow after resolving merge conflicts.  

## Additions  
- Added new `Checkbox` component from shadcn  
- Integrated `Checkbox` into upload template for urgent order toggle  
- Updated `package.json` and `yarn.lock` with new dependency  

## Removals  
- Removed unused `limit` prop and related logic from `CustomInput`  
- Deleted redundant query parameter handling in upload page  
- Removed unnecessary `useMemo`, `useSearchParams`, and `initialOrderNumber` logic  

## Changes  
- Simplified `CustomInput` to rely on native HTML `maxLength` attribute  
- Refined upload form logic for better state handling  
- Updated urgent order checkbox UI to use new `Checkbox` component  
- Cleaned up merge conflicts and ensured stable page rendering  

## Testing  
- Verified checkbox toggle behavior in reupload mode  
- Confirmed upload form validation and submission still function correctly  
- Built project locally to confirm no residual merge errors  

## Screenshots  
- N/A  

## Todos  
- Add visual test for `Checkbox` component  
- Evaluate refactoring other boolean inputs to use the same component  

## Task Links  
- N/A  
