### PR TITLE
feat: filter reupload orders by price matching

### DIFF
--- a/packages/tv-ad-admin-next/app/api/upload/orders/route.ts
+++ b/packages/tv-ad-admin-next/app/api/upload/orders/route.ts
@@ -31,7 +31,6 @@ export async function GET() {
       variables: {
         where: {
           member: { id: { equals: currentUser.memberId } },
-          needsModification: { equals: false },
           OR: [
             { state: { equals: ORDER_STATE.PENDING_UPLOAD } },
             { state: { equals: ORDER_STATE.PENDING_QUOTE_CONFIRMATION } },

--- a/packages/tv-ad-admin-next/components/upload/order-select-field.tsx
+++ b/packages/tv-ad-admin-next/components/upload/order-select-field.tsx
@@ -17,7 +17,7 @@ import { layout, ORDER_STATE } from '@/constants'
 import { OrderRecordForUploadQuery } from '@/graphql/queries/orders'
 import FileIcon from '@/public/icons/file.svg'
 import { cn } from '@/utils'
-
+import { getOldOrderPrice } from '@/utils/order-grouping'
 
 type OrderSelectFieldProps = {
   orders: OrderRecordForUploadQuery[]
@@ -46,11 +46,27 @@ export default function OrderSelectField({
     const items: SelectGroupItem[] = []
 
     const uploadOrders = orders.filter(
-      (o) => o.state === ORDER_STATE.PENDING_UPLOAD
+      (o) =>
+        o.state === ORDER_STATE.PENDING_UPLOAD && o.needsModification === false
     )
-    const reuploadOrders = orders.filter(
-      (o) => o.state === ORDER_STATE.PENDING_QUOTE_CONFIRMATION
-    )
+    const reuploadPrice = [
+      ...new Set(
+        orders
+          .filter(
+            (o) => o.state === ORDER_STATE.PENDING_UPLOAD && o.needsModification
+          )
+          .map((o: OrderRecordForUploadQuery) =>
+            o.price && o.price > 1000 ? o.price - 1000 : o.price
+          )
+      ),
+    ]
+
+    const reuploadOrders = orders.filter((o) => {
+      return (
+        o.state === ORDER_STATE.PENDING_QUOTE_CONFIRMATION &&
+        reuploadPrice.includes(getOldOrderPrice(o))
+      )
+    })
 
     if (uploadOrders.length > 0) {
       items.push({ type: 'label', label: '新訂單' })

--- a/packages/tv-ad-admin-next/graphql/queries/orders.ts
+++ b/packages/tv-ad-admin-next/graphql/queries/orders.ts
@@ -132,6 +132,9 @@ export type OrderRecordForUploadQuery = Pick<
   | 'image'
   | 'state'
   | 'isUrgent'
+  | 'isReviewed'
+  | 'needsModification'
+  | 'price'
 > & {
   orderNumber: string
 }
@@ -148,6 +151,7 @@ export const getOrdersForUpload = gql`
       id
       orderNumber
       name
+      price
       member {
         id
       }
@@ -165,6 +169,8 @@ export const getOrdersForUpload = gql`
       }
       state
       isUrgent
+      needsModification
+      isReviewed
     }
   }
 `

--- a/packages/tv-ad-admin-next/utils/order-grouping.ts
+++ b/packages/tv-ad-admin-next/utils/order-grouping.ts
@@ -5,9 +5,13 @@ import { OrderStateMap, ORDER_STATE } from '@/constants'
 import {
   type OrderRecordForList,
   type OrderRecordForDashboard,
+  type OrderRecordForUploadQuery,
 } from '@/graphql/queries/orders'
 
 type RelatedOrder = { id: string } | Array<{ id: string }>
+
+const REVIEWED_ORDER_PRICE = 400
+const UNREVIEWED_ORDER_PRICE = 600
 
 /**
  * 將訂單分組並排序
@@ -128,4 +132,8 @@ export function getOrdersState(
     state: state as keyof typeof OrderStateMap,
     count: count,
   }))
+}
+
+export const getOldOrderPrice = (order: OrderRecordForUploadQuery) => {
+  return order.isReviewed ? REVIEWED_ORDER_PRICE : UNREVIEWED_ORDER_PRICE
 }


### PR DESCRIPTION
## 修改內容

修正訂單上傳頁面的訂單選擇邏輯，新增根據價格來過濾重新上傳訂單的功能。

- 新增價格相關欄位查詢（price、isReviewed、needsModification）
- 根據舊訂單價格來過濾需要重新上傳的訂單
- 修正訂單分類邏輯，區分新上傳和重新上傳訂單

新上傳規則：狀態為「待上傳素材」，且有勾選「needsModification」。
待重新上傳訂單規則：狀態為「待重新上傳訂單」，且新訂單內有符合其價位的訂單。

舊訂單價錢計算：
因為沒辦法知道他要不要急件（交給 input 處理）因此如果有 `isReviewed`（標籤為「是否審核前」，不知是否需要改說明？）就是 400、沒有的話就是 600。