### PR TITLE
feat(gtm): add GTM class names and data-gtm attributes for analytics tracking

### DIFF
--- a/packages/mirror-tv-next/components/homepage/latest-and-editor-choices-with-live.tsx
+++ b/packages/mirror-tv-next/components/homepage/latest-and-editor-choices-with-live.tsx
@@ -96,7 +96,7 @@ export default async function LatestAndEditorChoicesWithLive({
         <EditorChoicesSwiper editorChoices={editorChoices} />
       </section>
       <GPTAd pageKey="home" adKey="MB_M2" />
-      <AdTvAdminMobileBanner />
+      <AdTvAdminMobileBanner location="home" />
       <section className={styles.latest}>
         <UiHeadingBordered
           title={latestListTitle}

--- a/packages/mirror-tv-next/components/layout/header/header-top.tsx
+++ b/packages/mirror-tv-next/components/layout/header/header-top.tsx
@@ -30,6 +30,8 @@ export default function HeaderTop({ sponsors }: HeaderTopProps) {
           <div className={styles.adBanner}>
             <Link
               href={TV_AD_ADMIN_OEN_URL}
+              className="GTM-banner-click-personal-ads"
+              data-gtm="header-personal-ads"
               target="_blank"
               rel="noreferrer noopener"
             >

--- a/packages/mirror-tv-next/components/shared/ad-tv-admin-mobile-banner.tsx
+++ b/packages/mirror-tv-next/components/shared/ad-tv-admin-mobile-banner.tsx
@@ -7,7 +7,11 @@ import { SHOW_TV_AD_ADMIN_BANNER } from '~/constants/environment-variables'
 
 import styles from './_styles/ad-tv-admin-mobile-banner.module.scss'
 
-export default function AdTvAdminMobileBanner() {
+export default function AdTvAdminMobileBanner({
+  location = 'article',
+}: {
+  location?: 'article' | 'home'
+}) {
   if (!SHOW_TV_AD_ADMIN_BANNER) {
     return null
   }
@@ -17,6 +21,8 @@ export default function AdTvAdminMobileBanner() {
       <Link
         href={TV_AD_ADMIN_OEN_URL}
         target="_blank"
+        className="GTM-banner-click-personal-ads"
+        data-gtm={`mobile-${location}-personal-ads`}
         rel="noreferrer noopener"
       >
         <Image


### PR DESCRIPTION
feat(gtm): add GTM tracking for header and mobile banners  

Added GTM `className` and `data-gtm` attributes for header and mobile ad banners to enable click analytics. Updated mobile banner to support `location` prop for contextual tracking.  

## Additions  
- Added GTM class and data attributes to header and mobile banners  

## Changes  
- Updated `AdTvAdminMobileBanner` to accept `location` prop  

## Testing  
- Verified GTM triggers on header and homepage banners  

## Todos  
- N/A  

## Task Links  
[鏡新聞官網個人廣告入口banner埋GA event - Asana](https://app.asana.com/1/614399484723017/project/1212000093376836/task/1212060918561160?focus=true)
