### PR TITLE
fix(env): correct SHOW_TV_AD_ADMIN_BANNER handling based on environment config

### DIFF
--- a/packages/mirror-tv-next/constants/environment-variables.ts
+++ b/packages/mirror-tv-next/constants/environment-variables.ts
@@ -1,7 +1,6 @@
 // 這裡管理的是在 Build 階段就會寫死數值的環境變數 (通常為 `NEXT_PUBLCI_` 開頭)
 const ENV = process.env.NEXT_PUBLIC_ENV || 'local'
-const SHOW_TV_AD_ADMIN_BANNER =
-  process.env.NEXT_PUBLIC_SHOW_TV_AD_ADMIN_BANNER === 'true'
+let SHOW_TV_AD_ADMIN_BANNER: boolean
 let SITE_URL: string
 let GTM_ID: string
 let GLOBAL_CACHE_SETTING: number
@@ -31,6 +30,7 @@ switch (ENV) {
     HOMEPAGE_JSON_URL =
       'https://storage.googleapis.com/static-mnews-tw-prod/files/json/topic_video.json'
     GA4_ID = 'G-SZR4JRJ0G2'
+    SHOW_TV_AD_ADMIN_BANNER = false
     break
 
   case 'staging':
@@ -47,6 +47,7 @@ switch (ENV) {
     HOMEPAGE_JSON_URL =
       'https://storage.googleapis.com/static-mnews-tw-staging/files/json/topic_video.json'
     GA4_ID = 'G-8Q9RVB3K0E'
+    SHOW_TV_AD_ADMIN_BANNER = false
     break
 
   case 'dev':
@@ -63,6 +64,7 @@ switch (ENV) {
     HOMEPAGE_JSON_URL =
       'https://storage.googleapis.com/static-mnews-tw-dev/files/json/topic_video.json'
     GA4_ID = 'G-YZ07T9YJ6T'
+    SHOW_TV_AD_ADMIN_BANNER = true
     break
 
   default:
@@ -79,6 +81,7 @@ switch (ENV) {
     HOMEPAGE_JSON_URL =
       'https://storage.googleapis.com/static-mnews-tw-dev/files/json/topic_video.json'
     GA4_ID = 'G-YZ07T9YJ6T'
+    SHOW_TV_AD_ADMIN_BANNER = true
     break
 }
 


### PR DESCRIPTION
- Updated logic to use environment-specific configuration for `SHOW_TV_AD_ADMIN_BANNER`  
- Removed reliance on `process.env.NEXT_PUBLIC_SHOW_TV_AD_ADMIN_BANNER` for runtime checks  