### PR TITLE
chore(constants): add CUSTOMER_SERVICE_EMAIL and update customer support address  

### DIFF
--- a/packages/mirror-tv-next/components/layout/footer.tsx
+++ b/packages/mirror-tv-next/components/layout/footer.tsx
@@ -1,6 +1,9 @@
 import Image from 'next/image'
 import Link from 'next/link'
-import { HEADER_BOTTOM_LINKS } from '~/constants/constant'
+import {
+  CUSTOMER_SERVICE_EMAIL,
+  HEADER_BOTTOM_LINKS,
+} from '~/constants/constant'
 import styles from './_styles/footer.module.scss'
 
 const footerRightList = [
@@ -93,7 +96,9 @@ export default function Footer(): JSX.Element {
               </p>
               <p className={styles.info}>
                 <span>客服信箱: </span>
-                <a href="mailto:mnews.cs@mnews.com.tw">mnews.cs@mnews.com.tw</a>
+                <a href={`mailto:${CUSTOMER_SERVICE_EMAIL}`}>
+                  {CUSTOMER_SERVICE_EMAIL}
+                </a>
               </p>
             </div>
           </div>

--- a/packages/mirror-tv-next/components/ombuds/ombuds-intro.tsx
+++ b/packages/mirror-tv-next/components/ombuds/ombuds-intro.tsx
@@ -1,6 +1,7 @@
 import styles from './_styles/ombuds-intro.module.scss'
 import ArticleContentVideo from '~/components/shared/article-content-video'
 import Link from 'next/link'
+import { CUSTOMER_SERVICE_EMAIL } from '~/constants/constant'
 
 export default function ombudsIntro() {
   return (
@@ -57,10 +58,10 @@ export default function ombudsIntro() {
               <p className={styles.tel}>（02）7752-5678</p>
               <p>或洽客服信箱</p>
               <Link
-                href="mailto:mnews.cs@mnews.com.tw"
+                href={`mailto:${CUSTOMER_SERVICE_EMAIL}`}
                 className={styles.reportMail}
               >
-                mnews.cs@mnews.com.tw
+                {CUSTOMER_SERVICE_EMAIL}
               </Link>
             </div>
           </div>

--- a/packages/mirror-tv-next/constants/constant.ts
+++ b/packages/mirror-tv-next/constants/constant.ts
@@ -4,6 +4,7 @@ const META_DESCRIPTION: string =
   '鏡電視股份有限公司創立「鏡新聞」，以多元、專業、深度、國際、藝文、弱勢為特色，期待提供給大家耳目一新的優質新聞內容，也歡迎閱聽人隨時給我們建議。'
 const META_SITE_URL = 'https://www.mnews.tw'
 const TV_AD_ADMIN_OEN_URL = 'https://mnews.oen.tw/'
+const CUSTOMER_SERVICE_EMAIL = 'mnews.cs@mnews.tw'
 
 const HEADER_BOTTOM_LINKS = {
   ombuds: '/ombuds',
@@ -50,4 +51,5 @@ export {
   CONTACT_MAPPING,
   META_SITE_URL,
   TV_AD_ADMIN_OEN_URL,
+  CUSTOMER_SERVICE_EMAIL,
 }


### PR DESCRIPTION
Centralize customer service email in constants and replace hardcoded addresses in related components.  

## Additions  
- Added `CUSTOMER_SERVICE_EMAIL` constant in `packages/mirror-tv-next/constants/constant.ts`.  

## Removals  
- N/A  

## Changes  
- Updated `footer.tsx` to reference `CUSTOMER_SERVICE_EMAIL` instead of hardcoded `mailto:mnews.cs@mnews.com.tw`.  
- Updated `ombuds-intro.tsx` to use the same constant for consistency.  

## Testing  
- Verified that footer and ombuds intro pages correctly render the email link.  
- Checked that clicking the email link opens the default mail client with the correct address.  

## Screenshots  
- N/A  

## Todos  
- N/A  

## Task Links  
[更改footer客服信箱成mnews.cs@mnews.tw - Asana](https://app.asana.com/1/614399484723017/project/1199408264065173/task/1212400103876708?focus=true)
