### PR TITLE
feat: Implement GCS Fuse static file fetching strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,7 @@ coverage
 # Bower dependency directory (https://bower.io/)
 bower_components
 
-# node-waf configuration
+# node-waf ㄏㄜuration
 .lock-wscript
 
 # Compiled binary addons (https://nodejs.org/api/addons.html)
@@ -132,3 +132,7 @@ lib
 
 # cursor
 .cursor
+
+# gemini
+.gemini
+GEMINI.md

--- a/packages/mirror-tv-next/app/_actions/homepage/latest-posts-and-editor-choices.tsx
+++ b/packages/mirror-tv-next/app/_actions/homepage/latest-posts-and-editor-choices.tsx
@@ -15,7 +15,6 @@ import {
 
 import { fetchStaticJson } from '~/utils/fetch-static-json'
 import { createDataFetchingChain } from '~/utils/fetch-function'
-import { ENV } from '~/constants/environment-variables'
 
 const HeroImageSchema = z.object({
   urlDesktopSized: z.string().optional(),

--- a/packages/mirror-tv-next/app/_actions/homepage/latest-posts-and-editor-choices.tsx
+++ b/packages/mirror-tv-next/app/_actions/homepage/latest-posts-and-editor-choices.tsx
@@ -13,6 +13,7 @@ import {
   fetchEditorChoices,
 } from '~/graphql/query/editor-choices'
 
+import { fetchStaticJson } from '~/utils/fetch-static-json'
 import { createDataFetchingChain } from '~/utils/fetch-function'
 import { ENV } from '~/constants/environment-variables'
 
@@ -184,16 +185,7 @@ type GetLatestPostsServerActionType = {
 }
 
 async function fetchLatestPostsAndEditorChoices({ page }: { page: number }) {
-  const timestamp = Date.now()
-  const resp = await fetch(
-    `https://storage.googleapis.com/static-mnews-tw-${ENV}/files/json/latest_posts0${page}.json?timestamp=${
-      timestamp / 100
-    }`
-  )
-  if (!resp.ok) {
-    throw new Error(`HTTP error! status: ${resp.status}`)
-  }
-  const jsonData = await resp.json()
+  const jsonData = await fetchStaticJson(`latest_posts0${page}.json`)
   const result = StaticHomepageResponseSchema.safeParse(jsonData)
 
   if (!result.success) {

--- a/packages/mirror-tv-next/app/_actions/homepage/topic-video.ts
+++ b/packages/mirror-tv-next/app/_actions/homepage/topic-video.ts
@@ -2,10 +2,7 @@
 
 import errors from '@twreporter/errors'
 import { z } from 'zod'
-import {
-  HOMEPAGE_TOPIC_JSON_URL,
-  HOMEPAGE_VIDEO_JSON_URL,
-} from '~/constants/environment-variables'
+import { fetchStaticJson } from '~/utils/fetch-static-json'
 import { createDataFetchingChain } from '~/utils/fetch-function'
 import type { Video } from '~/graphql/query/videos'
 import type { PromotionVideo } from '~/graphql/query/promotion-video'
@@ -71,20 +68,12 @@ const VideoDataSchema = z.object({
 })
 
 async function fetchTopicData() {
-  const resp = await fetch(HOMEPAGE_TOPIC_JSON_URL)
-  if (!resp.ok) {
-    throw new Error(`HTTP error! status: ${resp.status}`)
-  }
-  const jsonData = await resp.json()
+  const jsonData = await fetchStaticJson('topic.json')
   return TopicDataSchema.parse(jsonData)
 }
 
 async function fetchVideoData() {
-  const resp = await fetch(HOMEPAGE_VIDEO_JSON_URL)
-  if (!resp.ok) {
-    throw new Error(`HTTP error! status: ${resp.status}`)
-  }
-  const jsonData = await resp.json()
+  const jsonData = await fetchStaticJson('video.json')
   return VideoDataSchema.parse(jsonData)
 }
 

--- a/packages/mirror-tv-next/app/_actions/homepage/weather.ts
+++ b/packages/mirror-tv-next/app/_actions/homepage/weather.ts
@@ -1,25 +1,15 @@
 'use server'
 
 import { createErrorLogger } from '~/utils/log'
-import {
-  GLOBAL_CACHE_SETTING,
-  WEATHER_JSON_URL,
-} from '~/constants/environment-variables'
 import { type CityAndWeather } from '~/components/homepage/weather-main'
+import { fetchStaticJson } from '~/utils/fetch-static-json'
 
 export const fetchWeather = async (): Promise<CityAndWeather | undefined> => {
   const errorLogger = createErrorLogger('Error occurs while fetching weather')
 
   try {
-    const resp = await fetch(WEATHER_JSON_URL, {
-      next: { revalidate: GLOBAL_CACHE_SETTING },
-    })
+    const rawWeatherData = await fetchStaticJson('weather.json')
 
-    if (!resp.ok) {
-      throw new Error(`HTTP error! status: ${resp.status}`)
-    }
-
-    const rawWeatherData = await resp.json()
     const data = JSON.parse(JSON.stringify(rawWeatherData))
     // Ensure data is parsed and not referencing the original object
     // https://github.com/vercel/next.js/issues/47447

--- a/packages/mirror-tv-next/app/_actions/popular-data.tsx
+++ b/packages/mirror-tv-next/app/_actions/popular-data.tsx
@@ -1,22 +1,14 @@
 'use server'
 import errors from '@twreporter/errors'
-import {
-  GLOBAL_CACHE_SETTING,
-  POPULAR_POSTS_URL,
-} from '~/constants/environment-variables'
+import { POPULAR_POSTS_FILE_NAME } from '~/constants/environment-variables'
 import { type RawPopularPost } from '~/types/popular-post'
+import { fetchStaticJson } from '~/utils/fetch-static-json'
+
 async function fetchPopularPosts(): Promise<{ data: RawPopularPost[] }> {
   try {
-    const res = await fetch(POPULAR_POSTS_URL, {
-      next: { revalidate: GLOBAL_CACHE_SETTING },
-    })
-
-    if (!res.ok) {
-      console.error('Failed to fetch popular posts data')
-      return { data: [] } as { data: RawPopularPost[] }
-    }
-
-    const rawData = await res.json()
+    const rawData = await fetchStaticJson<{ report: RawPopularPost[] }>(
+      POPULAR_POSTS_FILE_NAME
+    )
     const data = JSON.parse(JSON.stringify(rawData))
     // Ensure data is parsed and not referencing the original object
     // https://github.com/vercel/next.js/issues/47447

--- a/packages/mirror-tv-next/app/category/[slug]/page.tsx
+++ b/packages/mirror-tv-next/app/category/[slug]/page.tsx
@@ -9,10 +9,11 @@ import PostsListManager from '~/components/category/posts-list-manager'
 import UiFeaturePost from '~/components/category/ui-feature-post'
 import UiHeadingBordered from '~/components/shared/ui-heading-bordered'
 import {
-  FEATURE_POSTS_URL,
+  FEATURE_POSTS_FILE_NAME,
   GLOBAL_CACHE_SETTING,
   SITE_URL,
 } from '~/constants/environment-variables'
+import { fetchStaticJson } from '~/utils/fetch-static-json'
 import { type Category } from '~/graphql/query/category'
 import styles from '~/styles/pages/category.module.scss'
 import { FeaturePost } from '~/types/api-data'
@@ -59,7 +60,7 @@ export async function generateMetadata({
   let firstPost = null
 
   const fetchFeaturePosts = (): Promise<FeaturePostsResponse> =>
-    fetch(FEATURE_POSTS_URL).then((res) => res.json())
+    fetchStaticJson(FEATURE_POSTS_FILE_NAME)
 
   const [featurePostResult] = await Promise.allSettled([fetchFeaturePosts()])
 
@@ -171,7 +172,7 @@ export default async function CategoryPage({
   }
 
   const fetchFeaturePosts = (): Promise<FeaturePostsResponse> =>
-    fetch(FEATURE_POSTS_URL).then((res) => res.json())
+    fetchStaticJson(FEATURE_POSTS_FILE_NAME)
 
   const fetchSalesPosts = () => fetchSales({ take: 4, pageName: 'category' })
   const [featurePostResult, salesResult] = await Promise.allSettled([

--- a/packages/mirror-tv-next/app/category/video/page.tsx
+++ b/packages/mirror-tv-next/app/category/video/page.tsx
@@ -2,8 +2,8 @@ import type { Metadata } from 'next'
 import {
   GLOBAL_CACHE_SETTING,
   SITE_URL,
-  POPULAR_VIDEOS_JSON_URL,
 } from '~/constants/environment-variables'
+import { fetchStaticJson } from '~/utils/fetch-static-json'
 import { handleResponse, formatArticleCard, FormattedPostCard } from '~/utils'
 import type { Category } from '~/graphql/query/category'
 import { fetchFeatureCategories } from '~/graphql/query/categories'
@@ -84,12 +84,7 @@ export default async function VideoCategoryPage() {
     })
 
   const fetchPopularPosts = () =>
-    fetch(POPULAR_VIDEOS_JSON_URL, {
-      next: { revalidate: GLOBAL_CACHE_SETTING },
-    }).then((res) => {
-      // use type assertion to eliminate any
-      return res.json() as unknown as RowPopularVideoData
-    })
+    fetchStaticJson<RowPopularVideoData>('popular-videonews-list.json')
 
   const fetchPromotionVideos = () =>
     fetchPromotionVideosServerAction({

--- a/packages/mirror-tv-next/app/layout.tsx
+++ b/packages/mirror-tv-next/app/layout.tsx
@@ -10,9 +10,10 @@ import { META_DESCRIPTION, SITE_TITLE } from '~/constants/constant'
 import {
   GLOBAL_CACHE_SETTING,
   GTM_ID,
-  HEADER_JSON_URL,
   SITE_URL,
+  HEADER_JSON_FILE_NAME,
 } from '~/constants/environment-variables'
+import { fetchStaticJson } from '~/utils/fetch-static-json'
 import '~/styles/global.css'
 import CompassFit from '~/components/ads/compass-fit'
 import TagManagerWrapper from '~/app/tag-manager'
@@ -85,15 +86,10 @@ export default async function RootLayout({
     'Error occurs while fetching latest posts'
   )
   try {
-    const data = await fetch(HEADER_JSON_URL, {
-      next: { revalidate: GLOBAL_CACHE_SETTING },
-    }).then((res) => {
-      // use type assertion to eliminate any
-      return res.json() as unknown as HeaderData
-    })
+    const data = await fetchStaticJson<HeaderData>(HEADER_JSON_FILE_NAME)
     initialHeaderData = data
   } catch (error) {
-    console.error('Failed to fetch popular posts:', error)
+    console.error('Failed to fetch header data:', error)
   }
   console.log('GTM_ID', GTM_ID)
 

--- a/packages/mirror-tv-next/app/schedule/page.tsx
+++ b/packages/mirror-tv-next/app/schedule/page.tsx
@@ -4,9 +4,9 @@ import type { Metadata } from 'next'
 import ScheduleTable from '~/components/schedule/schedule-table'
 import {
   GLOBAL_CACHE_SETTING,
-  SCHEDULE_JSON_URL,
   SITE_URL,
 } from '~/constants/environment-variables'
+import { fetchStaticJson } from '~/utils/fetch-static-json'
 import styles from '~/styles/pages/schedule-page.module.scss'
 import type { Schedule } from '~/types/common'
 import dynamic from 'next/dynamic'
@@ -34,16 +34,7 @@ type WeekDate = {
 
 async function getData() {
   try {
-    const res = await fetch(SCHEDULE_JSON_URL, {
-      next: { revalidate: GLOBAL_CACHE_SETTING },
-    })
-
-    if (!res.ok) {
-      console.error('Failed to fetch schedule data')
-      return []
-    }
-
-    return res.json()
+    return await fetchStaticJson<Schedule[]>('tv-schedule.json')
   } catch (err) {
     const annotatingError = errors.helpers.wrap(
       err,
@@ -60,14 +51,14 @@ async function getData() {
         }),
       })
     )
-    return
+    return []
   }
 }
 
 export default async function SchedulePage() {
   let schedule: Schedule[] = []
 
-  schedule = await getData()
+  schedule = (await getData()) ?? []
 
   const dayOfWeekMap: { [key: string]: string } = {
     Monday: '星期一',

--- a/packages/mirror-tv-next/components/flash-news/main-flash-news.tsx
+++ b/packages/mirror-tv-next/components/flash-news/main-flash-news.tsx
@@ -1,8 +1,8 @@
 import errors from '@twreporter/errors'
 import {
-  FLASH_NEWS_JSON_URL,
   GLOBAL_CACHE_SETTING,
 } from '~/constants/environment-variables'
+import { fetchStaticJson } from '~/utils/fetch-static-json'
 import styles from './_styles/main-flash-news.module.scss'
 import type { FlashNews } from '~/types/common'
 import UiMobFlashNews from './ui-mob-flash-news'
@@ -10,16 +10,7 @@ import UiPcFlashNews from './ui-pc-flash-news'
 
 async function getData() {
   try {
-    const res = await fetch(FLASH_NEWS_JSON_URL, {
-      next: { revalidate: GLOBAL_CACHE_SETTING },
-    })
-
-    if (!res.ok) {
-      console.error('Failed to fetch flash news data')
-      return { allPosts: [] }
-    }
-
-    return res.json()
+    return await fetchStaticJson<{ allPosts: FlashNews[] }>('flash_news.json')
   } catch (err) {
     const annotatingError = errors.helpers.wrap(
       err,
@@ -36,14 +27,14 @@ async function getData() {
         }),
       })
     )
-    return
+    return { allPosts: [] }
   }
 }
 
 export default async function MainFlashNews() {
   let flashNews: FlashNews[] = []
 
-  const { allPosts } = await getData()
+  const { allPosts } = (await getData()) ?? { allPosts: [] }
   flashNews = allPosts
 
   return (

--- a/packages/mirror-tv-next/components/flash-news/main-flash-news.tsx
+++ b/packages/mirror-tv-next/components/flash-news/main-flash-news.tsx
@@ -1,7 +1,4 @@
 import errors from '@twreporter/errors'
-import {
-  GLOBAL_CACHE_SETTING,
-} from '~/constants/environment-variables'
 import { fetchStaticJson } from '~/utils/fetch-static-json'
 import styles from './_styles/main-flash-news.module.scss'
 import type { FlashNews } from '~/types/common'

--- a/packages/mirror-tv-next/components/layout/header/main-header.tsx
+++ b/packages/mirror-tv-next/components/layout/header/main-header.tsx
@@ -3,27 +3,17 @@ import MobileNav from '~/components/layout/header/mobile-header/mobile-nav'
 import type { Category } from '~/graphql/query/category'
 import type { Sponsor } from '~/graphql/query/sponsors'
 
-import {
-  GLOBAL_CACHE_SETTING,
-  HEADER_JSON_URL,
-} from '~/constants/environment-variables'
+import { HEADER_JSON_FILE_NAME } from '~/constants/environment-variables'
+import { fetchStaticJson } from '~/utils/fetch-static-json'
 import styles from './_styles/main-header.module.scss'
 import HeaderBottom from './header-bottom'
 import HeaderNav from './header-nav'
 import HeaderTop from './header-top'
+import type { HeaderData } from '~/types/header'
 
 async function getData() {
   try {
-    const res = await fetch(HEADER_JSON_URL, {
-      next: { revalidate: GLOBAL_CACHE_SETTING },
-    })
-
-    if (!res.ok) {
-      console.error('Failed to fetch header data')
-      return { allSponsors: [], allCategories: [], allShows: [] }
-    }
-
-    return res.json()
+    return await fetchStaticJson<HeaderData>(HEADER_JSON_FILE_NAME)
   } catch (err) {
     const annotatingError = errors.helpers.wrap(
       err,
@@ -40,7 +30,7 @@ async function getData() {
         }),
       })
     )
-    return
+    return { allSponsors: [], allCategories: [], allShows: [] }
   }
 }
 

--- a/packages/mirror-tv-next/components/show/_slug/podcast/podcasts-list-handler.tsx
+++ b/packages/mirror-tv-next/components/show/_slug/podcast/podcasts-list-handler.tsx
@@ -1,18 +1,12 @@
 import errors from '@twreporter/errors'
 import type { Podcast } from '~/types/common'
-import { ENV } from '~/constants/environment-variables'
-import axios from 'axios'
+import { fetchStaticJson } from '~/utils/fetch-static-json'
 import PodcastsList from './podcasts-list'
 
 export default async function PodcastsListHandler() {
   let podcasts: Podcast[]
   try {
-    const podcastsEndpoint =
-      ENV === 'prod' || ENV === 'staging'
-        ? 'https://www.mnews.tw/json/podcast_list.json'
-        : 'https://dev.mnews.tw/json/podcast_list.json'
-    const response = await axios.get(podcastsEndpoint)
-    podcasts = response.data
+    podcasts = await fetchStaticJson<Podcast[]>('podcast_list.json')
   } catch (err) {
     const annotatingError = errors.helpers.wrap(
       err,

--- a/packages/mirror-tv-next/constants/environment-variables.ts
+++ b/packages/mirror-tv-next/constants/environment-variables.ts
@@ -12,10 +12,11 @@ let YOUTUBE_API_URL: string
 let FEATURE_POSTS_URL: string
 let GA4_ID: string
 let FEATURE_2025_HOMEPAGE_STYLE: 'on' | 'off'
-let JSON_BASE_URL: string
-let WEATHER_JSON_URL: string
-let HOMEPAGE_TOPIC_JSON_URL: string
-let HOMEPAGE_VIDEO_JSON_URL: string
+// let JSON_BASE_URL: string
+// let WEATHER_JSON_URL: string
+// let HOMEPAGE_TOPIC_JSON_URL: string
+// let HOMEPAGE_VIDEO_JSON_URL: string
+let STATIC_FILE_DOMAIN: string
 
 const TIMESTAMP_FOR_CACHE = '?t=' + Date.now() / 10
 
@@ -23,8 +24,7 @@ switch (ENV) {
   case 'prod':
     SITE_URL = 'https://mnews.tw'
     YOUTUBE_API_URL = 'https://mnews.tw'
-    JSON_BASE_URL =
-      'https://storage.googleapis.com/static-mnews-tw-prod/files/json'
+    STATIC_FILE_DOMAIN = 'storage.googleapis.com/static-mnews-tw-prod'
     GTM_ID = 'GTM-PK7VRFX'
     GLOBAL_CACHE_SETTING = 0
     HEADER_JSON_URL = `${SITE_URL}/json/header_v2-1.json`
@@ -33,9 +33,6 @@ switch (ENV) {
     POPULAR_POSTS_URL = `${SITE_URL}/json/popularlist.json`
     POPULAR_VIDEOS_JSON_URL = `${SITE_URL}/json/popular-videonews-list.json`
     FEATURE_POSTS_URL = `${SITE_URL}/json/category_features_news.json`
-    WEATHER_JSON_URL = `${JSON_BASE_URL}/weather.json`
-    HOMEPAGE_TOPIC_JSON_URL = `${JSON_BASE_URL}/topic.json`
-    HOMEPAGE_VIDEO_JSON_URL = `${JSON_BASE_URL}/video.json${TIMESTAMP_FOR_CACHE}`
     GA4_ID = 'G-SZR4JRJ0G2'
     FEATURE_2025_HOMEPAGE_STYLE = 'off'
 
@@ -44,9 +41,7 @@ switch (ENV) {
   case 'staging':
     SITE_URL = 'https://staging.mnews.tw'
     YOUTUBE_API_URL = 'https://staging.mnews.tw'
-    JSON_BASE_URL =
-      'https://storage.googleapis.com/static-mnews-tw-staging/files/json'
-    WEATHER_JSON_URL = `${JSON_BASE_URL}/weather.json`
+    STATIC_FILE_DOMAIN = 'storage.googleapis.com/static-mnews-tw-staging'
     GTM_ID = 'GTM-NFH6FDH'
     GLOBAL_CACHE_SETTING = 0
     HEADER_JSON_URL = `${SITE_URL}/json/header_v2-1.json`
@@ -55,8 +50,6 @@ switch (ENV) {
     POPULAR_POSTS_URL = `${SITE_URL}/json/popularlist.json`
     POPULAR_VIDEOS_JSON_URL = `${SITE_URL}/json/popular-videonews-list.json`
     FEATURE_POSTS_URL = `${SITE_URL}/json/featured_categories_post.json`
-    HOMEPAGE_TOPIC_JSON_URL = `${JSON_BASE_URL}/topic.json`
-    HOMEPAGE_VIDEO_JSON_URL = `${JSON_BASE_URL}/video.json${TIMESTAMP_FOR_CACHE}`
     GA4_ID = 'G-8Q9RVB3K0E'
     FEATURE_2025_HOMEPAGE_STYLE = 'off'
     break
@@ -64,9 +57,7 @@ switch (ENV) {
   case 'dev':
     SITE_URL = 'https://dev.mnews.tw'
     YOUTUBE_API_URL = 'https://dev.mnews.tw'
-    JSON_BASE_URL =
-      'https://storage.googleapis.com/static-mnews-tw-dev/files/json'
-    WEATHER_JSON_URL = `${JSON_BASE_URL}/weather.json`
+    STATIC_FILE_DOMAIN = 'storage.googleapis.com/static-mnews-tw-dev'
     GTM_ID = 'GTM-TVZ26W8'
     GLOBAL_CACHE_SETTING = 0
     HEADER_JSON_URL = `${SITE_URL}/json/header_v2-1.json`
@@ -75,8 +66,6 @@ switch (ENV) {
     POPULAR_POSTS_URL = `https://mnews.tw/json/popularlist.json`
     POPULAR_VIDEOS_JSON_URL = `${SITE_URL}/json/popular-videonews-list.json`
     FEATURE_POSTS_URL = `${SITE_URL}/json/category_features_news.json`
-    HOMEPAGE_TOPIC_JSON_URL = `${JSON_BASE_URL}/topic.json`
-    HOMEPAGE_VIDEO_JSON_URL = `${JSON_BASE_URL}/video.json${TIMESTAMP_FOR_CACHE}`
     GA4_ID = 'G-YZ07T9YJ6T'
     FEATURE_2025_HOMEPAGE_STYLE = 'on'
     break
@@ -84,9 +73,7 @@ switch (ENV) {
   default:
     SITE_URL = 'https://dev.mnews.tw'
     YOUTUBE_API_URL = 'https://dev.mnews.tw'
-    JSON_BASE_URL =
-      'https://storage.googleapis.com/static-mnews-tw-dev/files/json'
-    WEATHER_JSON_URL = `${JSON_BASE_URL}/weather.json`
+    STATIC_FILE_DOMAIN = 'storage.googleapis.com/static-mnews-tw-dev'
     GTM_ID = 'GTM-TVZ26W8'
     GLOBAL_CACHE_SETTING = 0
     HEADER_JSON_URL = `${SITE_URL}/json/header_v2-1.json`
@@ -95,12 +82,16 @@ switch (ENV) {
     POPULAR_POSTS_URL = `${SITE_URL}/json/popularlist.json`
     POPULAR_VIDEOS_JSON_URL = `${SITE_URL}/json/popular-videonews-list.json`
     FEATURE_POSTS_URL = `${SITE_URL}/json/category_features_news.json`
-    HOMEPAGE_TOPIC_JSON_URL = `${JSON_BASE_URL}/topic.json`
-    HOMEPAGE_VIDEO_JSON_URL = `${JSON_BASE_URL}/video.json${TIMESTAMP_FOR_CACHE}`
     GA4_ID = 'G-YZ07T9YJ6T'
     FEATURE_2025_HOMEPAGE_STYLE = 'on'
     break
 }
+
+const bucketDomain = process.env.GCS_FUSE_STATIC_BUCKET ?? STATIC_FILE_DOMAIN
+const JSON_BASE_URL = `https://${bucketDomain}/files/json`
+const WEATHER_JSON_URL = `${JSON_BASE_URL}/weather.json`
+const HOMEPAGE_TOPIC_JSON_URL = `${JSON_BASE_URL}/topic.json`
+const HOMEPAGE_VIDEO_JSON_URL = `${JSON_BASE_URL}/video.json${TIMESTAMP_FOR_CACHE}`
 
 export {
   ENV,

--- a/packages/mirror-tv-next/constants/environment-variables.ts
+++ b/packages/mirror-tv-next/constants/environment-variables.ts
@@ -3,22 +3,10 @@ const ENV = process.env.NEXT_PUBLIC_ENV || 'local'
 let SITE_URL: string
 let GTM_ID: string
 let GLOBAL_CACHE_SETTING: number
-let HEADER_JSON_URL: string
-let FLASH_NEWS_JSON_URL: string
-let SCHEDULE_JSON_URL: string
-let POPULAR_POSTS_URL: string
-let POPULAR_VIDEOS_JSON_URL: string
 let YOUTUBE_API_URL: string
-let FEATURE_POSTS_URL: string
 let GA4_ID: string
 let FEATURE_2025_HOMEPAGE_STYLE: 'on' | 'off'
-// let JSON_BASE_URL: string
-// let WEATHER_JSON_URL: string
-// let HOMEPAGE_TOPIC_JSON_URL: string
-// let HOMEPAGE_VIDEO_JSON_URL: string
 let STATIC_FILE_DOMAIN: string
-
-const TIMESTAMP_FOR_CACHE = '?t=' + Date.now() / 10
 
 switch (ENV) {
   case 'prod':
@@ -27,12 +15,6 @@ switch (ENV) {
     STATIC_FILE_DOMAIN = 'storage.googleapis.com/static-mnews-tw-prod'
     GTM_ID = 'GTM-PK7VRFX'
     GLOBAL_CACHE_SETTING = 0
-    HEADER_JSON_URL = `${SITE_URL}/json/header_v2-1.json`
-    FLASH_NEWS_JSON_URL = `${SITE_URL}/json/flash_news.json`
-    SCHEDULE_JSON_URL = `${SITE_URL}/json/tv-schedule.json`
-    POPULAR_POSTS_URL = `${SITE_URL}/json/popularlist.json`
-    POPULAR_VIDEOS_JSON_URL = `${SITE_URL}/json/popular-videonews-list.json`
-    FEATURE_POSTS_URL = `${SITE_URL}/json/category_features_news.json`
     GA4_ID = 'G-SZR4JRJ0G2'
     FEATURE_2025_HOMEPAGE_STYLE = 'off'
 
@@ -44,12 +26,6 @@ switch (ENV) {
     STATIC_FILE_DOMAIN = 'storage.googleapis.com/static-mnews-tw-staging'
     GTM_ID = 'GTM-NFH6FDH'
     GLOBAL_CACHE_SETTING = 0
-    HEADER_JSON_URL = `${SITE_URL}/json/header_v2-1.json`
-    FLASH_NEWS_JSON_URL = `${SITE_URL}/json/flash_news.json`
-    SCHEDULE_JSON_URL = `${SITE_URL}/json/tv-schedule.json`
-    POPULAR_POSTS_URL = `${SITE_URL}/json/popularlist.json`
-    POPULAR_VIDEOS_JSON_URL = `${SITE_URL}/json/popular-videonews-list.json`
-    FEATURE_POSTS_URL = `${SITE_URL}/json/featured_categories_post.json`
     GA4_ID = 'G-8Q9RVB3K0E'
     FEATURE_2025_HOMEPAGE_STYLE = 'off'
     break
@@ -60,12 +36,6 @@ switch (ENV) {
     STATIC_FILE_DOMAIN = 'storage.googleapis.com/static-mnews-tw-dev'
     GTM_ID = 'GTM-TVZ26W8'
     GLOBAL_CACHE_SETTING = 0
-    HEADER_JSON_URL = `${SITE_URL}/json/header_v2-1.json`
-    FLASH_NEWS_JSON_URL = `${SITE_URL}/json/flash_news.json`
-    SCHEDULE_JSON_URL = `${SITE_URL}/json/tv-schedule.json`
-    POPULAR_POSTS_URL = `https://mnews.tw/json/popularlist.json`
-    POPULAR_VIDEOS_JSON_URL = `${SITE_URL}/json/popular-videonews-list.json`
-    FEATURE_POSTS_URL = `${SITE_URL}/json/category_features_news.json`
     GA4_ID = 'G-YZ07T9YJ6T'
     FEATURE_2025_HOMEPAGE_STYLE = 'on'
     break
@@ -76,12 +46,6 @@ switch (ENV) {
     STATIC_FILE_DOMAIN = 'storage.googleapis.com/static-mnews-tw-dev'
     GTM_ID = 'GTM-TVZ26W8'
     GLOBAL_CACHE_SETTING = 0
-    HEADER_JSON_URL = `${SITE_URL}/json/header_v2-1.json`
-    FLASH_NEWS_JSON_URL = `${SITE_URL}/json/flash_news.json`
-    SCHEDULE_JSON_URL = `${SITE_URL}/json/tv-schedule.json`
-    POPULAR_POSTS_URL = `${SITE_URL}/json/popularlist.json`
-    POPULAR_VIDEOS_JSON_URL = `${SITE_URL}/json/popular-videonews-list.json`
-    FEATURE_POSTS_URL = `${SITE_URL}/json/category_features_news.json`
     GA4_ID = 'G-YZ07T9YJ6T'
     FEATURE_2025_HOMEPAGE_STYLE = 'on'
     break
@@ -89,26 +53,22 @@ switch (ENV) {
 
 const bucketDomain = process.env.GCS_FUSE_STATIC_BUCKET ?? STATIC_FILE_DOMAIN
 const JSON_BASE_URL = `https://${bucketDomain}/files/json`
-const WEATHER_JSON_URL = `${JSON_BASE_URL}/weather.json`
-const HOMEPAGE_TOPIC_JSON_URL = `${JSON_BASE_URL}/topic.json`
-const HOMEPAGE_VIDEO_JSON_URL = `${JSON_BASE_URL}/video.json${TIMESTAMP_FOR_CACHE}`
+const FEATURE_POSTS_FILE_NAME = 'category_features_news.json'
+const POPULAR_POSTS_FILE_NAME = 'popularlist.json'
+const WEATHER_JSON_FILE_NAME = 'weather.json'
+const HEADER_JSON_FILE_NAME = 'header_v2-1.json'
 
 export {
   ENV,
-  FLASH_NEWS_JSON_URL,
   GLOBAL_CACHE_SETTING,
   GTM_ID,
-  HEADER_JSON_URL,
-  SCHEDULE_JSON_URL,
   SITE_URL,
-  POPULAR_POSTS_URL,
-  POPULAR_VIDEOS_JSON_URL,
   YOUTUBE_API_URL,
-  FEATURE_POSTS_URL,
+  FEATURE_POSTS_FILE_NAME,
+  POPULAR_POSTS_FILE_NAME,
+  WEATHER_JSON_FILE_NAME,
+  HEADER_JSON_FILE_NAME,
   GA4_ID,
   FEATURE_2025_HOMEPAGE_STYLE,
   JSON_BASE_URL,
-  WEATHER_JSON_URL,
-  HOMEPAGE_TOPIC_JSON_URL,
-  HOMEPAGE_VIDEO_JSON_URL,
 }

--- a/packages/mirror-tv-next/pages/story/amp/[slug].tsx
+++ b/packages/mirror-tv-next/pages/story/amp/[slug].tsx
@@ -2,8 +2,9 @@ import AMPLayout from '~/components/story/amp/layout'
 import {
   ENV,
   GLOBAL_CACHE_SETTING,
-  POPULAR_POSTS_URL,
+  POPULAR_POSTS_FILE_NAME,
 } from '~/constants/environment-variables'
+import { fetchStaticJson } from '~/utils/fetch-static-json'
 import { getClient } from '~/apollo-client'
 import {
   fetchStoryBySlug as fetchStoryBySlugDocument,
@@ -524,11 +525,7 @@ export const getServerSideProps: GetServerSideProps<{
   }
 
   const fetchPopularList = () =>
-    fetch(POPULAR_POSTS_URL, {
-      next: { revalidate: GLOBAL_CACHE_SETTING },
-    }).then((res) => {
-      return res.json() as unknown as { report: RawPopularPost[] }
-    })
+    fetchStaticJson<{ report: RawPopularPost[] }>(POPULAR_POSTS_FILE_NAME)
 
   const client = getClient()
 

--- a/packages/mirror-tv-next/pages/story/amp/[slug].tsx
+++ b/packages/mirror-tv-next/pages/story/amp/[slug].tsx
@@ -1,9 +1,5 @@
 import AMPLayout from '~/components/story/amp/layout'
-import {
-  ENV,
-  GLOBAL_CACHE_SETTING,
-  POPULAR_POSTS_FILE_NAME,
-} from '~/constants/environment-variables'
+import { ENV, POPULAR_POSTS_FILE_NAME } from '~/constants/environment-variables'
 import { fetchStaticJson } from '~/utils/fetch-static-json'
 import { getClient } from '~/apollo-client'
 import {

--- a/packages/mirror-tv-next/types/header.ts
+++ b/packages/mirror-tv-next/types/header.ts
@@ -1,9 +1,5 @@
-type Category = {
-  name: string
-  slug: string
-  sortOrder: number | null
-  id: string
-}
+import type { Category } from '~/graphql/query/category'
+import type { Sponsor } from '~/graphql/query/sponsors'
 
 type BannerImage = {
   urlMobileSized: string
@@ -18,26 +14,6 @@ export type Show = {
   sortOrder: string | null
   bannerImg: BannerImage | null
   listShow?: boolean | null
-}
-
-type Sponsor = {
-  id: string
-  title: string | null
-  url: string | null
-  logo: {
-    urlMobileSized: string
-  }
-  mobile: {
-    urlMobileSized: string
-  } | null
-  tablet: {
-    urlMobileSized: string
-  } | null
-  topic: {
-    id: string
-    slug: string
-    name: string
-  } | null
 }
 
 export type HeaderData = {

--- a/packages/mirror-tv-next/utils/fetch-static-json.ts
+++ b/packages/mirror-tv-next/utils/fetch-static-json.ts
@@ -1,0 +1,49 @@
+'use server'
+
+import fs from 'fs/promises'
+import { isServer } from '~/utils/common'
+import {
+  GLOBAL_CACHE_SETTING,
+  JSON_BASE_URL,
+} from '~/constants/environment-variables'
+
+/**
+ * Fetch static JSON from local GCS FUSE mount if on server, otherwise fallback to HTTP fetch.
+ *
+ * @param filename - The JSON filename to fetch
+ */
+export async function fetchStaticJson<T = unknown>(
+  filename: string
+): Promise<T> {
+  const GCS_FUSE_MOUNT_DIR = process.env.GCS_FUSE_MOUNT_DIR ?? '/statics'
+
+  // 1. Try reading from local file system if on server
+  if (isServer()) {
+    try {
+      // Structure: [mount_dir]/files/json/[filename]
+      const filePath = `${GCS_FUSE_MOUNT_DIR}/files/json/${filename}`
+      const content = await fs.readFile(filePath, 'utf-8')
+      return JSON.parse(content) as T
+    } catch (err) {
+      // Fallback to fetch if file not found or unreadable
+      console.warn(
+        `[fetchStaticJson] Local read failed for ${filename}, falling back to HTTP fetch.`,
+        err
+      )
+    }
+  }
+
+  // 2. Fallback to HTTP fetch
+  const url = `${JSON_BASE_URL}/${filename}`
+  const res = await fetch(url, {
+    next: { revalidate: GLOBAL_CACHE_SETTING },
+  })
+
+  if (!res.ok) {
+    throw new Error(
+      `[fetchStaticJson] Failed to fetch ${url}: ${res.status} ${res.statusText}`
+    )
+  }
+
+  return res.json() as Promise<T>
+}

--- a/packages/mirror-tv-next/utils/fetch-static-json.ts
+++ b/packages/mirror-tv-next/utils/fetch-static-json.ts
@@ -1,5 +1,3 @@
-'use server'
-
 import fs from 'fs/promises'
 import { isServer } from '~/utils/common'
 import {


### PR DESCRIPTION
This PR introduces a hybrid data fetching strategy for static JSON resources. It prioritizes reading files directly from a local GCS Fuse mount point when the application is running on the server side. If the local read fails or the application is running on the client side, it gracefully falls back to standard HTTP requests. This update aims to improve performance and reduce latency for accessing static configurations and data.

## Additions

- **`packages/mirror-tv-next/utils/fetch-static-json.ts`**: Added a new utility function `fetchStaticJson` that attempts to read JSON files from the local file system (via `fs/promises`) and falls back to `fetch` upon failure.
- **Environment Variables**: Added `STATIC_FILE_DOMAIN` and specific file name constants (e.g., `FEATURE_POSTS_FILE_NAME`, `HEADER_JSON_FILE_NAME`) to `constants/environment-variables.ts` for better management.

## Removals

- **Redundant Constants**: Removed specific URL constants like `HEADER_JSON_URL`, `SCHEDULE_JSON_URL`, and `WEATHER_JSON_URL` from `constants/environment-variables.ts` in favor of a centralized base URL and file names.
- **Duplicate Types**: Removed `Category` and `Sponsor` type definitions from `packages/mirror-tv-next/types/header.ts`, replacing them with imports from GraphQL query types to ensure consistency.

## Changes

- **Refactored Data Fetching**: Updated multiple server actions and components (Homepage, Category pages, Layout, Schedule, Flash News) to use `fetchStaticJson` instead of direct `fetch` calls.
    - `app/_actions/homepage/*`
    - `app/category/[slug]/page.tsx`
    - `app/layout.tsx`
    - `app/schedule/page.tsx`
    - `components/flash-news/main-flash-news.tsx`
    - `components/layout/header/main-header.tsx`
- **Configuration Logic**: Updated `constants/environment-variables.ts` to dynamically construct `JSON_BASE_URL` based on the environment or GCS bucket configuration.

## Testing

1.  **Server-Side Fallback Verification**:
    -   Run the application locally without the GCS Fuse mount.
    -   Navigate to the Homepage and Category pages.
    -   Observe the console logs for warnings starting with `[fetchStaticJson] Local read failed...`, confirming that the system correctly falls back to HTTP fetching and the page still renders data successfully.
2.  **GCS Fuse Simulation (Optional)**:
    -   Mock the file system presence at `/statics/files/json/` (or configured `GCS_FUSE_MOUNT_DIR`).
    -   Verify that data is loaded directly from the file system without triggering network requests for those assets.
3.  **Regression Testing**:
    -   Verify that the Header, Flash News, Weather widget, and Schedule page display correct information across Dev/Staging environments.

## Screenshots

- N/A

## Todos

- N/A

## Task Links
[【電視GCS mount】前端-GCS改抓local JSON - Asana](https://app.asana.com/1/614399484723017/project/1212714038945191/task/1212516068569366?focus=true)