### PR TITLE
fix(mirror-tv-next): update static JSON fetching logic to support flexible paths

### DIFF
--- a/packages/mirror-tv-next/app/_actions/homepage/topic-video.ts
+++ b/packages/mirror-tv-next/app/_actions/homepage/topic-video.ts
@@ -68,12 +68,12 @@ const VideoDataSchema = z.object({
 })
 
 async function fetchTopicData() {
-  const jsonData = await fetchStaticJson('topic.json')
+  const jsonData = await fetchStaticJson('topic.json', true)
   return TopicDataSchema.parse(jsonData)
 }
 
 async function fetchVideoData() {
-  const jsonData = await fetchStaticJson('video.json')
+  const jsonData = await fetchStaticJson('video.json', true)
   return VideoDataSchema.parse(jsonData)
 }
 

--- a/packages/mirror-tv-next/app/_actions/homepage/weather.ts
+++ b/packages/mirror-tv-next/app/_actions/homepage/weather.ts
@@ -8,7 +8,7 @@ export const fetchWeather = async (): Promise<CityAndWeather | undefined> => {
   const errorLogger = createErrorLogger('Error occurs while fetching weather')
 
   try {
-    const rawWeatherData = await fetchStaticJson('weather.json')
+    const rawWeatherData = await fetchStaticJson('weather.json', true)
 
     const data = JSON.parse(JSON.stringify(rawWeatherData))
     // Ensure data is parsed and not referencing the original object

--- a/packages/mirror-tv-next/constants/environment-variables.ts
+++ b/packages/mirror-tv-next/constants/environment-variables.ts
@@ -52,10 +52,9 @@ switch (ENV) {
 }
 
 const bucketDomain = process.env.GCS_FUSE_STATIC_BUCKET ?? STATIC_FILE_DOMAIN
-const JSON_BASE_URL = `https://${bucketDomain}/files/json`
+const JSON_BASE_URL = `https://${bucketDomain}`
 const FEATURE_POSTS_FILE_NAME = 'category_features_news.json'
 const POPULAR_POSTS_FILE_NAME = 'popularlist.json'
-const WEATHER_JSON_FILE_NAME = 'weather.json'
 const HEADER_JSON_FILE_NAME = 'header_v2-1.json'
 
 export {
@@ -66,7 +65,6 @@ export {
   YOUTUBE_API_URL,
   FEATURE_POSTS_FILE_NAME,
   POPULAR_POSTS_FILE_NAME,
-  WEATHER_JSON_FILE_NAME,
   HEADER_JSON_FILE_NAME,
   GA4_ID,
   FEATURE_2025_HOMEPAGE_STYLE,

--- a/packages/mirror-tv-next/utils/fetch-static-json.ts
+++ b/packages/mirror-tv-next/utils/fetch-static-json.ts
@@ -11,15 +11,17 @@ import {
  * @param filename - The JSON filename to fetch
  */
 export async function fetchStaticJson<T = unknown>(
-  filename: string
+  filename: string,
+  hasFilePrefix: boolean = false
 ): Promise<T> {
   const GCS_FUSE_MOUNT_DIR = process.env.GCS_FUSE_MOUNT_DIR ?? '/statics'
+  const pathPrefix = hasFilePrefix ? '/files/json' : '/json'
 
   // 1. Try reading from local file system if on server
   if (isServer()) {
     try {
-      // Structure: [mount_dir]/files/json/[filename]
-      const filePath = `${GCS_FUSE_MOUNT_DIR}/files/json/${filename}`
+      // Structure: [mount_dir]/[prefix]/[filename]
+      const filePath = `${GCS_FUSE_MOUNT_DIR}${pathPrefix}/${filename}`
       const content = await fs.readFile(filePath, 'utf-8')
       return JSON.parse(content) as T
     } catch (err) {
@@ -32,7 +34,7 @@ export async function fetchStaticJson<T = unknown>(
   }
 
   // 2. Fallback to HTTP fetch
-  const url = `${JSON_BASE_URL}/${filename}`
+  const url = `${JSON_BASE_URL}${pathPrefix}/${filename}`
   const res = await fetch(url, {
     next: { revalidate: GLOBAL_CACHE_SETTING },
   })


### PR DESCRIPTION
- Update `fetchStaticJson` utility to support both `/json/` and `/files/json/` paths via a new `hasFilePrefix` parameter.
- Modify `JSON_BASE_URL` in `environment-variables.ts` to point to the bucket root instead of a fixed subpath.
- Update fetching logic for `topic.json`, `video.json`, and `weather.json` to use the `/files/json/` prefix.
- Remove redundant global constants and use string literals for localized JSON fetches.