### PR TITLE
fix: fix home page thumbnail field validation and mapping

### DIFF
--- a/packages/mirror-tv-next/app/_actions/homepage/latest-posts-and-editor-choices.tsx
+++ b/packages/mirror-tv-next/app/_actions/homepage/latest-posts-and-editor-choices.tsx
@@ -53,7 +53,7 @@ const StaticLatestPostSchema = z.object({
   slug: z.string(),
   style: z.string().optional(),
   name: z.string(),
-  thumbnail: z.string().optional(),
+  thumbnail: z.string().nullable().optional(),
   partner: z
     .object({
       name: z.string(),
@@ -283,6 +283,7 @@ async function getLatestPostsAndEditorChoices({
           style: post.style,
           name: post.name,
           partner: post.partner,
+          thumbnail: post.thumbnail,
           heroImage:
             typeof post.heroImage === 'string'
               ? { urlOriginal: post.heroImage }


### PR DESCRIPTION
- Update StaticLatestPostSchema to allow thumbnail as nullable to prevent Zod validation errors on external posts.
- Include the thumbnail field in the server action's data mapping to ensure images are correctly passed to the frontend.