### PR TITLE
feat: align story and external page layouts with homepage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ GEMINI.md
 # CLAUDE
 .claude
 CLAUDE.md
+
+# codex
+AGENTS.md

--- a/packages/mirror-tv-next/app/external/[slug]/_styles/external.module.scss
+++ b/packages/mirror-tv-next/app/external/[slug]/_styles/external.module.scss
@@ -40,7 +40,7 @@
     max-width: $max-width-xxl;
     display: flex;
     flex-direction: row;
-    gap: 96px;
+    gap: 60px;
     padding-top: 60px;
   }
 }

--- a/packages/mirror-tv-next/app/external/[slug]/_styles/external.module.scss
+++ b/packages/mirror-tv-next/app/external/[slug]/_styles/external.module.scss
@@ -9,10 +9,10 @@
     max-width: $story-wrapper-max-width-md;
   }
   @include media-breakpoint-up(xl) {
-    max-width: $story-max-width-xl;
+    max-width: $max-width-xl;
   }
   @include media-breakpoint-up(xxl) {
-    max-width: $story-max-width-xl;
+    max-width: $max-width-xl;
   }
 }
 

--- a/packages/mirror-tv-next/app/story/[slug]/_styles/story.module.scss
+++ b/packages/mirror-tv-next/app/story/[slug]/_styles/story.module.scss
@@ -40,7 +40,7 @@
     max-width: $max-width-xxl;
     display: flex;
     flex-direction: row;
-    gap: 96px;
+    gap: 60px;
     padding-top: 60px;
   }
 }

--- a/packages/mirror-tv-next/app/story/[slug]/_styles/story.module.scss
+++ b/packages/mirror-tv-next/app/story/[slug]/_styles/story.module.scss
@@ -9,10 +9,10 @@
     max-width: $story-wrapper-max-width-md;
   }
   @include media-breakpoint-up(xl) {
-    max-width: $story-max-width-xl;
+    max-width: $max-width-xl;
   }
   @include media-breakpoint-up(xxl) {
-    max-width: $story-max-width-xl;
+    max-width: $max-width-xl;
   }
 }
 

--- a/packages/mirror-tv-next/components/homepage/_styles/latest-and-editor-choices-with-live.module.scss
+++ b/packages/mirror-tv-next/components/homepage/_styles/latest-and-editor-choices-with-live.module.scss
@@ -46,7 +46,7 @@
   justify-content: center;
   @include media-breakpoint-up(xl) {
     flex-direction: row-reverse;
-    width: 1120px;
+    width: $max-width-xl;
     margin: 0 auto;
     gap: 23px;
   }

--- a/packages/mirror-tv-next/components/ombuds/_styles/fetchArticleData-pc.module.scss
+++ b/packages/mirror-tv-next/components/ombuds/_styles/fetchArticleData-pc.module.scss
@@ -20,7 +20,7 @@
     margin: 0 auto 32px;
   }
   @include media-breakpoint-up(xl) {
-    width: 1120px;
+    width: $max-width-xl;
     margin-bottom: 48px;
   }
 }

--- a/packages/mirror-tv-next/components/ombuds/_styles/iconLinkList.module.scss
+++ b/packages/mirror-tv-next/components/ombuds/_styles/iconLinkList.module.scss
@@ -1,4 +1,5 @@
 @import '/styles/theme/breakpoints';
+@import '/styles/theme/variable';
 
 .infoList {
   margin: 0 16px 48px;
@@ -13,7 +14,7 @@
     column-gap: 16px;
   }
   @include media-breakpoint-up(xl) {
-    width: 1120px;
+    width: $max-width-xl;
     grid-template-columns: repeat(6, 1fr);
   }
 }

--- a/packages/mirror-tv-next/components/ombuds/_styles/ombuds-intro.module.scss
+++ b/packages/mirror-tv-next/components/ombuds/_styles/ombuds-intro.module.scss
@@ -21,7 +21,7 @@
     width: 696px;
   }
   @include media-breakpoint-up(xl) {
-    width: 1120px;
+    width: $max-width-xl;
   }
 }
 

--- a/packages/mirror-tv-next/components/shared/_styles/ui-list-posts-aside.module.scss
+++ b/packages/mirror-tv-next/components/shared/_styles/ui-list-posts-aside.module.scss
@@ -29,6 +29,13 @@
   }
 }
 
+.articleWrapper {
+  @include media-breakpoint-up(xl) {
+    width: 100%;
+    box-sizing: border-box;
+  }
+}
+
 .listTitle {
   width: max-content;
   border-image: linear-gradient(

--- a/packages/mirror-tv-next/components/shared/ui-list-posts-aside.tsx
+++ b/packages/mirror-tv-next/components/shared/ui-list-posts-aside.tsx
@@ -20,6 +20,7 @@ export default function UiListPostsAside({
     <div
       className={[
         styles.wrapper,
+        page === 'story' ? styles.articleWrapper : '',
         page === 'category' ? styles.bordered : '',
         className,
       ].join(' ')}

--- a/packages/mirror-tv-next/components/story/_styles/aside.module.scss
+++ b/packages/mirror-tv-next/components/story/_styles/aside.module.scss
@@ -16,7 +16,7 @@
   }
   @include media-breakpoint-up(xl) {
     flex-direction: column;
-    width: 384px;
+    width: 460px;
     padding: 0;
     background-color: #f4f5f6;
     position: sticky;

--- a/packages/mirror-tv-next/styles/pages/anchorperson-page.module.scss
+++ b/packages/mirror-tv-next/styles/pages/anchorperson-page.module.scss
@@ -1,4 +1,5 @@
 @import '/styles/theme/breakpoints';
+@import '/styles/theme/variable';
 
 .main {
   background: #303030;
@@ -28,7 +29,7 @@
   }
 
   @include media-breakpoint-up(xl) {
-    width: 1120px;
+    width: $max-width-xl;
   }
 
   @include media-breakpoint-up(xxl) {

--- a/packages/mirror-tv-next/styles/pages/category-layout.module.scss
+++ b/packages/mirror-tv-next/styles/pages/category-layout.module.scss
@@ -1,4 +1,5 @@
 @import '/styles/theme/breakpoints';
+@import '/styles/theme/variable';
 
 .category {
   margin: 0 auto;
@@ -10,7 +11,7 @@
     padding: 28px 0 50px;
   }
   @include media-breakpoint-up(xl) {
-    max-width: 1120px;
+    max-width: $max-width-xl;
     display: flex;
   }
   @include media-breakpoint-up(xxl) {

--- a/packages/mirror-tv-next/styles/pages/category-video-page.module.scss
+++ b/packages/mirror-tv-next/styles/pages/category-video-page.module.scss
@@ -1,4 +1,5 @@
 @import '/styles/theme/breakpoints';
+@import '/styles/theme/variable';
 
 .main {
   margin: 0 auto;
@@ -10,7 +11,7 @@
     padding: 28px 0 50px;
   }
   @include media-breakpoint-up(xl) {
-    max-width: 1120px;
+    max-width: $max-width-xl;
   }
   @include media-breakpoint-up(xxl) {
     max-width: 1200px;

--- a/packages/mirror-tv-next/styles/theme/_variable.scss
+++ b/packages/mirror-tv-next/styles/theme/_variable.scss
@@ -13,7 +13,6 @@ $footer-max-width: 1568px; // 1440px(content) + 45 px(left padding) + 83 px(righ
 
 $story-max-width-md: 688px;
 $story-wrapper-max-width-md: 600px;
-$story-max-width-xl: 1080px;
 $story-hero-image-full-screen: calc(-50vw + 50%);
 
 $color-grey: #e7e7e7;


### PR DESCRIPTION
This PR aligns the layout of the story and external article pages with the homepage design. It standardizes the maximum page width across various components by replacing hardcoded 1120px values and deprecated variables with a unified theme variable. Additionally, it adjusts the story sidebar width and the gap between the main content and the sidebar for a more consistent visual experience. A minor chore update to `.gitignore` is also included.

## Additions
- Added `# codex` section in `.gitignore` to exclude `AGENTS.md`.
- Added missing `@import '/styles/theme/variable';` in several SCSS modules.
- Added `articleWrapper` class to `UiListPostsAside` to handle full-width styling and box-sizing specifically for story pages.

## Removals
- Removed the deprecated `$story-max-width-xl` variable from `_variable.scss`.

## Changes
- Replaced hardcoded `1120px` and `$story-max-width-xl` with the unified `$max-width-xl` variable across multiple page and component styles (story, external, homepage, ombuds, category, etc.).
- Increased the story sidebar width from `384px` to `460px` at the `xl` breakpoint.
- Reduced the flex gap between the main content and sidebar from `96px` to `60px` in story and external pages.
- Fixed EOF newline formatting in `.gitignore`.

## Testing
- Verified visually that story and external pages now match the 1120px maximum width of the homepage on desktop breakpoints.
- Checked sidebar proportions and spacing on large screens to ensure UI integrity.

## Screenshots
- N/A

## Todos
- None

## Task Links
[【電視web】文章頁寬度改和首頁一樣 - Asana](https://app.asana.com/1/614399484723017/project/1213022666184704/task/1213404256303231?focus=true)