### PR TITLE
fix: support K6 API image formats and correct AMP image fit

### DIFF
--- a/packages/mirror-tv-next/app/_actions/homepage/latest-posts-and-editor-choices.tsx
+++ b/packages/mirror-tv-next/app/_actions/homepage/latest-posts-and-editor-choices.tsx
@@ -15,30 +15,42 @@ import {
 
 import { fetchStaticJson } from '~/utils/fetch-static-json'
 import { createDataFetchingChain } from '~/utils/fetch-function'
-import type { HeroImage } from '~/types/common'
+import type { FormattableHeroImage } from '~/types/hero-image'
 
-// New JSON format schema (for latest_posts.json)
-const NewHeroImageSchema = z.object({
-  original: z.string().optional(),
-  w1600: z.string().optional(),
-  w1200: z.string().optional(),
-  w800: z.string().optional(),
-  w480: z.string().optional(),
-})
+const ImageApiDataSchema = z
+  .object({
+    url: z.string().optional(),
+    original: z.object({ url: z.string() }).optional(),
+    w2400: z.object({ url: z.string() }).optional(),
+    w1600: z.object({ url: z.string() }).optional(),
+    w1200: z.object({ url: z.string() }).optional(),
+    w800: z.object({ url: z.string() }).optional(),
+    w480: z.object({ url: z.string() }).optional(),
+  })
+  .passthrough()
 
-// Legacy format schema (for GraphQL compatibility)
-const LegacyHeroImageSchema = z.object({
-  urlDesktopSized: z.string().optional(),
-  urlTabletSized: z.string().optional(),
-  urlMobileSized: z.string().optional(),
-  urlTinySized: z.string().optional(),
-  urlOriginal: z.string().optional(),
-})
+const HeroImageObjectSchema = z
+  .object({
+    original: z.string().optional(),
+    w2400: z.string().optional(),
+    w1600: z.string().optional(),
+    w1200: z.string().optional(),
+    w800: z.string().optional(),
+    w480: z.string().optional(),
+    urlDesktopSized: z.string().optional(),
+    urlTabletSized: z.string().optional(),
+    urlMobileSized: z.string().optional(),
+    urlTinySized: z.string().optional(),
+    urlOriginal: z.string().optional(),
+    imageApiData: z.union([z.string(), ImageApiDataSchema]).optional(),
+  })
+  .passthrough()
 
-// Combined schema that accepts both formats
-const HeroImageSchema = z.union([NewHeroImageSchema, LegacyHeroImageSchema])
-
-const FlexibleHeroImageSchema = z.union([z.string(), HeroImageSchema, z.null()])
+const FlexibleHeroImageSchema = z.union([
+  z.string(),
+  HeroImageObjectSchema,
+  z.null(),
+])
 
 const StaticEditorChoiceSchema = z.object({
   name: z.string(),
@@ -46,7 +58,7 @@ const StaticEditorChoiceSchema = z.object({
   heroImage: FlexibleHeroImageSchema.optional(),
   heroVideo: z
     .object({
-      coverPhoto: HeroImageSchema.nullable(),
+      coverPhoto: HeroImageObjectSchema.nullable(),
     })
     .nullable()
     .optional(),
@@ -92,7 +104,7 @@ const StaticLatestPostSchema = z.object({
     .optional(),
   heroVideo: z
     .object({
-      coverPhoto: HeroImageSchema.nullable(),
+      coverPhoto: HeroImageObjectSchema.nullable(),
     })
     .nullable()
     .optional(),
@@ -119,7 +131,7 @@ const ListingPostSchema = z.object({
   slug: z.string(),
   style: z.string().optional(),
   name: z.string(),
-  heroImage: HeroImageSchema.nullable(),
+  heroImage: HeroImageObjectSchema.nullable(),
   exclusive: z
     .any()
     .transform((val) => {
@@ -148,7 +160,7 @@ const PostWithCategorySchema = ListingPostSchema.extend({
   ),
   heroVideo: z
     .object({
-      coverPhoto: HeroImageSchema.nullable(),
+      coverPhoto: HeroImageObjectSchema.nullable(),
     })
     .nullable(),
 })
@@ -159,10 +171,10 @@ const GraphQLEditorChoicesResponseSchema = z.object({
       choice: z.object({
         name: z.string(),
         slug: z.string(),
-        heroImage: HeroImageSchema.nullable(),
+        heroImage: HeroImageObjectSchema.nullable(),
         heroVideo: z
           .object({
-            coverPhoto: HeroImageSchema.nullable(),
+            coverPhoto: HeroImageObjectSchema.nullable(),
           })
           .nullable(),
         exclusive: z
@@ -197,90 +209,19 @@ type GetLatestPostsServerActionType = {
   jsonPage: number
 }
 
-/**
- * Convert new heroImage format { original, w1600, w1200, w800, w480 } to legacy format { urlOriginal, urlDesktopSized, urlTabletSized, urlMobileSized, urlTinySized }
- * Filters out empty strings and returns null if no valid URLs are found
- */
-function convertHeroImageToLegacyFormat(
-  heroImage: z.infer<typeof FlexibleHeroImageSchema>
-): {
-  urlOriginal?: string
-  urlDesktopSized?: string
-  urlTabletSized?: string
-  urlMobileSized?: string
-  urlTinySized?: string
-} | null {
+function normalizeFlexibleHeroImage(
+  heroImage: z.infer<typeof FlexibleHeroImageSchema> | undefined
+): FormattableHeroImage {
   if (!heroImage) {
     return null
   }
 
-  // Handle string format
   if (typeof heroImage === 'string') {
-    return heroImage.trim() ? { urlOriginal: heroImage.trim() } : null
+    const urlOriginal = heroImage.trim()
+    return urlOriginal ? { urlOriginal } : null
   }
 
-  // If it's already in legacy format, filter out empty strings
-  if ('urlOriginal' in heroImage || 'urlDesktopSized' in heroImage) {
-    const result: {
-      urlOriginal?: string
-      urlDesktopSized?: string
-      urlTabletSized?: string
-      urlMobileSized?: string
-      urlTinySized?: string
-    } = {}
-
-    if (heroImage.urlOriginal?.trim()) {
-      result.urlOriginal = heroImage.urlOriginal.trim()
-    }
-    if (heroImage.urlDesktopSized?.trim()) {
-      result.urlDesktopSized = heroImage.urlDesktopSized.trim()
-    }
-    if (heroImage.urlTabletSized?.trim()) {
-      result.urlTabletSized = heroImage.urlTabletSized.trim()
-    }
-    if (heroImage.urlMobileSized?.trim()) {
-      result.urlMobileSized = heroImage.urlMobileSized.trim()
-    }
-    if (heroImage.urlTinySized?.trim()) {
-      result.urlTinySized = heroImage.urlTinySized.trim()
-    }
-
-    return Object.keys(result).length > 0 ? result : null
-  }
-
-  // Convert new format to legacy format
-  if ('original' in heroImage || 'w1600' in heroImage) {
-    const result: {
-      urlOriginal?: string
-      urlDesktopSized?: string
-      urlTabletSized?: string
-      urlMobileSized?: string
-      urlTinySized?: string
-    } = {}
-
-    // Only include non-empty strings
-    if (heroImage.original?.trim()) {
-      result.urlOriginal = heroImage.original.trim()
-    }
-    if (heroImage.w1600?.trim()) {
-      result.urlDesktopSized = heroImage.w1600.trim()
-    }
-    if (heroImage.w1200?.trim()) {
-      result.urlTabletSized = heroImage.w1200.trim()
-    } else if (heroImage.w1600?.trim()) {
-      result.urlTabletSized = heroImage.w1600.trim()
-    }
-    if (heroImage.w800?.trim()) {
-      result.urlMobileSized = heroImage.w800.trim()
-    }
-    if (heroImage.w480?.trim()) {
-      result.urlTinySized = heroImage.w480.trim()
-    }
-
-    return Object.keys(result).length > 0 ? result : null
-  }
-
-  return null
+  return heroImage
 }
 
 async function fetchLatestPostsAndEditorChoices({ page }: { page: number }) {
@@ -347,96 +288,38 @@ async function getLatestPostsAndEditorChoices({
       })
 
       const transformedChoices = (validatedData.choices || []).map((choice) => {
-        let heroImage: HeroImage | null = null
-
-        if (typeof choice.heroImage === 'string') {
-          heroImage = { urlOriginal: choice.heroImage }
-        } else if (choice.heroImage) {
-          const converted = convertHeroImageToLegacyFormat(choice.heroImage)
-          if (converted) {
-            heroImage = converted as HeroImage
-          }
-        }
-
-        const coverPhoto = choice.heroVideo?.coverPhoto
-          ? (convertHeroImageToLegacyFormat(
-              choice.heroVideo.coverPhoto
-            ) as HeroImage | null)
-          : null
-
         return {
           choice: {
             name: choice.name,
             slug: choice.slug,
             source: choice.source,
-            heroImage: (heroImage || {
-              urlOriginal: '',
-              urlDesktopSized: '',
-              urlTabletSized: '',
-              urlMobileSized: '',
-              urlTinySized: '',
-            }) as HeroImage,
+            heroImage: normalizeFlexibleHeroImage(choice.heroImage),
             heroVideo: choice.heroVideo
               ? {
-                  coverPhoto: (coverPhoto || {
-                    urlOriginal: '',
-                    urlDesktopSized: '',
-                    urlTabletSized: '',
-                    urlMobileSized: '',
-                    urlTinySized: '',
-                  }) as HeroImage | null,
+                  coverPhoto: choice.heroVideo.coverPhoto ?? null,
                 }
-              : {
-                  coverPhoto: {
-                    urlOriginal: '',
-                    urlDesktopSized: '',
-                    urlTabletSized: '',
-                    urlMobileSized: '',
-                    urlTinySized: '',
-                  } as HeroImage,
-                },
+              : null,
             exclusive: choice.exclusive ?? false,
           },
         }
       }) as EditorChoices[]
 
       const transformedPosts = validatedData.latest.map((post) => {
-        let heroImage: HeroImage | null = null
-
-        if (typeof post.heroImage === 'string') {
-          heroImage = { urlOriginal: post.heroImage }
-        } else if (post.heroImage) {
-          const converted = convertHeroImageToLegacyFormat(post.heroImage)
-          if (converted) {
-            heroImage = converted as HeroImage
-          }
-        }
-
-        const coverPhoto = post.heroVideo?.coverPhoto
-          ? (convertHeroImageToLegacyFormat(
-              post.heroVideo.coverPhoto
-            ) as HeroImage | null)
-          : null
-
         return {
           slug: post.slug,
           style: post.style,
           name: post.name,
-          heroImage: heroImage as HeroImage | null,
+          heroImage: normalizeFlexibleHeroImage(post.heroImage),
           publishTime: new Date(post.publishTime),
           categories: (post.categories || []).map((category) => ({
             slug: category.slug || category.name?.toLowerCase() || 'unknown',
             name: category.name,
           })),
-          heroVideo: {
-            coverPhoto: (coverPhoto || {
-              urlOriginal: '',
-              urlDesktopSized: '',
-              urlTabletSized: '',
-              urlMobileSized: '',
-              urlTinySized: '',
-            }) as HeroImage | null,
-          },
+          heroVideo: post.heroVideo
+            ? {
+                coverPhoto: post.heroVideo.coverPhoto ?? null,
+              }
+            : null,
           exclusive: post.exclusive,
           partner: post.partner,
         } as PostWithCategory
@@ -503,13 +386,12 @@ async function getLatestPostsAndEditorChoices({
           validatedEditorChoices.allEditorChoices.map((choice) => ({
             choice: {
               ...choice.choice,
-              heroImage: choice.choice.heroImage || {
-                urlOriginal: '',
-                urlDesktopSized: '',
-                urlTabletSized: '',
-                urlMobileSized: '',
-                urlTinySized: '',
-              },
+              heroImage: choice.choice.heroImage ?? null,
+              heroVideo: choice.choice.heroVideo
+                ? {
+                    coverPhoto: choice.choice.heroVideo.coverPhoto ?? null,
+                  }
+                : null,
             },
           }))
 
@@ -518,23 +400,9 @@ async function getLatestPostsAndEditorChoices({
             ...post,
             heroVideo: post.heroVideo
               ? {
-                  coverPhoto: post.heroVideo?.coverPhoto || {
-                    urlOriginal: '',
-                    urlDesktopSized: '',
-                    urlTabletSized: '',
-                    urlMobileSized: '',
-                    urlTinySized: '',
-                  },
+                  coverPhoto: post.heroVideo.coverPhoto ?? null,
                 }
-              : {
-                  coverPhoto: {
-                    urlOriginal: '',
-                    urlDesktopSized: '',
-                    urlTabletSized: '',
-                    urlMobileSized: '',
-                    urlTinySized: '',
-                  },
-                },
+              : null,
           })
         )
 
@@ -580,23 +448,9 @@ async function getLatestPostsAndEditorChoices({
         ...post,
         heroVideo: post.heroVideo
           ? {
-              coverPhoto: post.heroVideo?.coverPhoto || {
-                urlOriginal: '',
-                urlDesktopSized: '',
-                urlTabletSized: '',
-                urlMobileSized: '',
-                urlTinySized: '',
-              },
+              coverPhoto: post.heroVideo.coverPhoto ?? null,
             }
-          : {
-              coverPhoto: {
-                urlOriginal: '',
-                urlDesktopSized: '',
-                urlTabletSized: '',
-                urlMobileSized: '',
-                urlTinySized: '',
-              },
-            },
+          : null,
       })
     ) as PostWithCategory[]
 

--- a/packages/mirror-tv-next/app/_actions/homepage/latest-posts-and-editor-choices.tsx
+++ b/packages/mirror-tv-next/app/_actions/homepage/latest-posts-and-editor-choices.tsx
@@ -31,17 +31,20 @@ const ImageApiDataSchema = z
 
 const HeroImageObjectSchema = z
   .object({
+    // K6 flat image format.
     original: z.string().optional(),
     w2400: z.string().optional(),
     w1600: z.string().optional(),
     w1200: z.string().optional(),
     w800: z.string().optional(),
     w480: z.string().optional(),
+    // Legacy hero image fields still returned by some GraphQL responses.
     urlDesktopSized: z.string().optional(),
     urlTabletSized: z.string().optional(),
     urlMobileSized: z.string().optional(),
     urlTinySized: z.string().optional(),
     urlOriginal: z.string().optional(),
+    // GraphQL / API image payload.
     imageApiData: z.union([z.string(), ImageApiDataSchema]).optional(),
   })
   .passthrough()

--- a/packages/mirror-tv-next/app/_actions/homepage/topic-video.ts
+++ b/packages/mirror-tv-next/app/_actions/homepage/topic-video.ts
@@ -93,27 +93,6 @@ async function fetchVideoData() {
   return VideoDataSchema.parse(jsonData)
 }
 
-/**
- * Convert new heroImage format { w480, w800, original } to HeroImage format { urlOriginal, urlMobileSized, urlTabletSized }
- */
-function convertHeroImageToLegacyFormat(
-  heroImage: z.infer<typeof NewHeroImageSchema> | null
-): {
-  urlOriginal?: string
-  urlMobileSized?: string
-  urlTabletSized?: string
-} | null {
-  if (!heroImage) {
-    return null
-  }
-
-  return {
-    urlOriginal: heroImage.original,
-    urlMobileSized: heroImage.w800,
-    urlTabletSized: heroImage.w800,
-  }
-}
-
 async function fetchTopicVideoData() {
   const [topicData, videoData] = await Promise.all([
     fetchTopicData(),
@@ -182,7 +161,7 @@ async function getTopicVideo(): Promise<{
         slug: topic.slug,
         name: topic.name,
         sortDir: topic.sortDir,
-        heroImage: convertHeroImageToLegacyFormat(topic.heroImage),
+        heroImage: topic.heroImage,
         postDESC: topic.postDESC || [],
         postASC: topic.postASC || [],
       }))

--- a/packages/mirror-tv-next/app/_actions/popular-data.tsx
+++ b/packages/mirror-tv-next/app/_actions/popular-data.tsx
@@ -5,43 +5,9 @@ import {
   POPULAR_POSTS_URL,
 } from '~/constants/environment-variables'
 import {
-  type PopularListReportItem,
   type RawPopularListJson,
   type RawPopularPost,
 } from '~/types/popular-post'
-
-/**
- * Convert popularlist heroImage format { w480, w800, original? } to legacy format { urlOriginal, urlMobileSized, urlTabletSized, urlTinySized }
- * When original is missing, falls back to w800 or w480 so images still render.
- */
-function convertPopularPostHeroImage(
-  heroImage: PopularListReportItem['heroImage']
-): RawPopularPost['heroImage'] {
-  if (!heroImage) {
-    return null
-  }
-
-  // If it's already in legacy format, return as is
-  if ('urlOriginal' in heroImage || 'urlMobileSized' in heroImage) {
-    return heroImage as RawPopularPost['heroImage']
-  }
-
-  // Convert new format to legacy format (urlOriginal fallback: original ?? w800 ?? w480)
-  const urlOriginal =
-    heroImage.original?.trim() ||
-    heroImage.w800?.trim() ||
-    heroImage.w480?.trim() ||
-    undefined
-  if (!urlOriginal) {
-    return null
-  }
-  return {
-    urlOriginal,
-    urlMobileSized: heroImage.w800 ?? undefined,
-    urlTabletSized: heroImage.w800 ?? undefined,
-    urlTinySized: heroImage.w480 ?? undefined,
-  }
-}
 
 async function fetchPopularPosts(): Promise<{ data: RawPopularPost[] }> {
   try {
@@ -59,15 +25,7 @@ async function fetchPopularPosts(): Promise<{ data: RawPopularPost[] }> {
     // Ensure data is parsed and not referencing the original object
     // https://github.com/vercel/next.js/issues/47447
 
-    // Transform heroImage format (w480, w800) -> (urlOriginal, urlMobileSized, urlTabletSized, urlTinySized)
-    const transformedReport: RawPopularPost[] = (data.report ?? []).map(
-      (post: PopularListReportItem) => ({
-        ...post,
-        heroImage: convertPopularPostHeroImage(post.heroImage),
-      })
-    )
-
-    return { data: transformedReport }
+    return { data: (data.report ?? []) as RawPopularPost[] }
   } catch (err) {
     const annotatingError = errors.helpers.wrap(
       err,

--- a/packages/mirror-tv-next/app/category/[slug]/page.tsx
+++ b/packages/mirror-tv-next/app/category/[slug]/page.tsx
@@ -39,29 +39,6 @@ type FeaturePostsResponse = {
   allPosts: FeaturePost[]
 }
 
-/** Convert new featured_categories_news heroImage { resized } to HeroImage (legacy url* fields) */
-function convertFeaturedHeroImageToLegacy(
-  heroImage: RawFeaturedPost['heroImage']
-): FeaturePost['heroImage'] {
-  if (!heroImage?.resized) {
-    return {
-      urlOriginal: '',
-      urlDesktopSized: '',
-      urlTabletSized: '',
-      urlMobileSized: '',
-      urlTinySized: '',
-    }
-  }
-  const r = heroImage.resized
-  return {
-    urlOriginal: r.original ?? '',
-    urlDesktopSized: r.w1600 ?? r.w2400 ?? '',
-    urlTabletSized: r.w1200 ?? r.w1600 ?? '',
-    urlMobileSized: r.w800 ?? '',
-    urlTinySized: r.w480 ?? '',
-  }
-}
-
 /** Normalize featured_categories_news response to { allPosts: FeaturePost[] } for category feature-post lookup */
 function normalizeFeaturePostsResponse(
   data: FeaturePostsResponse | RawFeaturedCategoriesNewsJson | undefined
@@ -84,7 +61,7 @@ function normalizeFeaturePostsResponse(
         name: c.name ?? '',
         slug: c.slug ?? '',
       })),
-      heroImage: convertFeaturedHeroImageToLegacy(post.heroImage),
+      heroImage: post.heroImage,
     }))
     return { allPosts }
   }

--- a/packages/mirror-tv-next/app/category/video/page.tsx
+++ b/packages/mirror-tv-next/app/category/video/page.tsx
@@ -11,7 +11,6 @@ import { getClient } from '~/apollo-client'
 import { fetchVideoPostsItems } from '~/app/_actions/category-video'
 import styles from '~/styles/pages/category-video-page.module.scss'
 import VideoPostsList from '~/components/category/video/video-posts-list'
-import type { HeroImage } from '~/types/common'
 import UiShowsList from '~/components/category/video/ui-shows-list'
 import UiLinksList from '~/components/category/video/ui-links-list'
 import type { PromotionVideo } from '~/graphql/query/promotion-video'
@@ -30,6 +29,7 @@ import {
 import UiAsideVideosList from '~/components/shared/ui-aside-videos-list'
 import { getVideo } from '~/app/_actions/share/video'
 import { fetchPromotionVideosServerAction } from '~/app/_actions/share/promotion-videos'
+import type { FormattableHeroImage } from '~/types/hero-image'
 
 export const revalidate = GLOBAL_CACHE_SETTING
 
@@ -52,7 +52,7 @@ type ReportItem = {
   publishTime: string
   slug: string
   source?: string
-  heroImage: HeroImage
+  heroImage: FormattableHeroImage
 }
 
 type RowPopularVideoData = {

--- a/packages/mirror-tv-next/graphql/fragments/listing-post.ts
+++ b/packages/mirror-tv-next/graphql/fragments/listing-post.ts
@@ -1,11 +1,11 @@
 import gql from 'graphql-tag'
-import type { HeroImage } from '~/types/common'
+import type { FormattableHeroImage } from '~/types/hero-image'
 
 export type ListingPost = {
   slug: string
   style?: string | null
   name: string
-  heroImage: HeroImage | null
+  heroImage: FormattableHeroImage
   exclusive: boolean | null
   __typename?: 'Post'
 }

--- a/packages/mirror-tv-next/graphql/query/editor-choices.ts
+++ b/packages/mirror-tv-next/graphql/query/editor-choices.ts
@@ -1,13 +1,13 @@
 import gql from 'graphql-tag'
-import { HeroImage } from '~/types/common'
+import type { FormattableHeroImage } from '~/types/hero-image'
 
 export type EditorChoices = {
   choice: {
     name: string
     slug: string
     source?: string | null
-    heroImage: HeroImage | null
-    heroVideo?: { coverPhoto: HeroImage | null } | null
+    heroImage: FormattableHeroImage
+    heroVideo?: { coverPhoto: FormattableHeroImage } | null
     exclusive: boolean | null
   }
 }

--- a/packages/mirror-tv-next/graphql/query/posts.ts
+++ b/packages/mirror-tv-next/graphql/query/posts.ts
@@ -1,10 +1,10 @@
 import gql from 'graphql-tag'
 import { ListingPost, listingPost } from '../fragments/listing-post'
-import { HeroImage } from '~/types/common'
+import type { FormattableHeroImage } from '~/types/hero-image'
 
 export type PostCardItem = ListingPost & {
   publishTime: string
-  ogImage?: HeroImage | null
+  ogImage?: FormattableHeroImage
   __typename?: 'Post'
 }
 
@@ -15,7 +15,7 @@ export type PostWithCategory = ListingPost & {
     name: string
   }[]
   heroVideo?: {
-    coverPhoto: HeroImage | null
+    coverPhoto: FormattableHeroImage
   } | null
   __typename?: 'Post'
 }

--- a/packages/mirror-tv-next/graphql/query/topic.ts
+++ b/packages/mirror-tv-next/graphql/query/topic.ts
@@ -1,5 +1,6 @@
 import gql from 'graphql-tag'
 import type { HeroImage } from '~/types/common'
+import type { FormattableHeroImage } from '~/types/hero-image'
 import { ListingPost } from '../fragments/listing-post'
 
 export type Topic = {
@@ -58,7 +59,8 @@ export type SingleTopic = Topic & {
   itemsCount: number
 }
 
-export type FeatureTopic = Omit<Topic, 'briefApiData'> & {
+export type FeatureTopic = Omit<Topic, 'briefApiData' | 'heroImage'> & {
+  heroImage: FormattableHeroImage
   postDESC: {
     slug: string
     name: string

--- a/packages/mirror-tv-next/pages/story/amp/[slug].tsx
+++ b/packages/mirror-tv-next/pages/story/amp/[slug].tsx
@@ -360,6 +360,13 @@ export default function AmpPage({
             margin-right: 12px;
             flex-shrink: 0;
           }
+          .amp-card-list-item-image-image {
+            display: block;
+            overflow: hidden;
+          }
+          .amp-card-list-item-image-image img {
+            object-fit: cover;
+          }
           .amp-post-list-title-text,
           .amp-related-list-title-text {
             font-size: 16px;

--- a/packages/mirror-tv-next/types/api-data.ts
+++ b/packages/mirror-tv-next/types/api-data.ts
@@ -1,4 +1,4 @@
-import type { HeroImage } from './common'
+import type { FormattableHeroImage } from './hero-image'
 
 export type ApiData = {
   id: string
@@ -22,7 +22,7 @@ export type FeaturePost = {
   style: string
   publishTime: string
   categories: Category[]
-  heroImage: HeroImage
+  heroImage: FormattableHeroImage
 }
 
 export type FormatPlayListItems = {

--- a/packages/mirror-tv-next/types/featured-categories-news.ts
+++ b/packages/mirror-tv-next/types/featured-categories-news.ts
@@ -1,3 +1,5 @@
+import type { K6FlatHeroImage } from './hero-image'
+
 /**
  * Types for featured_categories_news.json
  */
@@ -14,18 +16,9 @@ export type RawFeaturedCategory = {
   createdAt?: string
 }
 
-export type RawFeaturedHeroImageResized = {
-  original?: string
-  w480?: string
-  w800?: string
-  w1200?: string
-  w1600?: string
-  w2400?: string
-}
-
 export type RawFeaturedPostHeroImage = {
   id?: string
-  resized?: RawFeaturedHeroImageResized
+  resized?: K6FlatHeroImage
 }
 
 export type RawFeaturedPostCategory = {

--- a/packages/mirror-tv-next/types/hero-image.ts
+++ b/packages/mirror-tv-next/types/hero-image.ts
@@ -1,0 +1,22 @@
+import type { HeroImage } from './common'
+
+export type K6FlatHeroImage = {
+  original?: string
+  w2400?: string
+  w1600?: string
+  w1200?: string
+  w800?: string
+  w480?: string
+}
+
+export type K6NestedHeroImage = {
+  id?: string
+  resized?: K6FlatHeroImage
+}
+
+export type FormattableHeroImage =
+  | HeroImage
+  | K6FlatHeroImage
+  | K6NestedHeroImage
+  | null
+  | undefined

--- a/packages/mirror-tv-next/types/popular-post.ts
+++ b/packages/mirror-tv-next/types/popular-post.ts
@@ -1,34 +1,22 @@
+import type { HeroImage } from './common'
+import type { K6FlatHeroImage } from './hero-image'
+
 export type RawPopularPost = {
   id: string
   name: string
   slug: string
   source: string
-  heroImage: {
-    urlMobileSized?: string
-    urlOriginal?: string
-    urlDesktopSized?: string
-    urlTabletSized?: string
-    urlTinySized?: string
-    // New format support
-    w480?: string
-    w800?: string
-    original?: string
-  } | null
+  heroImage: HeroImage | K6FlatHeroImage | null
   publishTime: string
 }
 
-/** Item shape as returned by popularlist.json (before heroImage transform) */
 export type PopularListReportItem = {
   id: string
   name: string
   slug: string
   source: string
   publishTime: string
-  heroImage: {
-    w480?: string
-    w800?: string
-    original?: string
-  } | null
+  heroImage: HeroImage | K6FlatHeroImage | null
 }
 
 /** Full popularlist.json response shape */

--- a/packages/mirror-tv-next/utils/image-handler.ts
+++ b/packages/mirror-tv-next/utils/image-handler.ts
@@ -1,6 +1,11 @@
 import { type PostCardItem } from '~/graphql/query/posts'
 import { Topic } from '~/graphql/query/topic'
 import type { HeroImage, ImageApiData } from '~/types/common'
+import type {
+  FormattableHeroImage,
+  K6FlatHeroImage,
+  K6NestedHeroImage,
+} from '~/types/hero-image'
 
 type Post = PostCardItem
 
@@ -31,102 +36,199 @@ function parseImageApiData(
   return imageApiData
 }
 
-function formatePostImage(post: Post | Topic): PostImage {
-  const images: PostImage = {
+function toNonEmptyString(value?: string | null) {
+  if (typeof value !== 'string') {
+    return undefined
+  }
+
+  const trimmedValue = value.trim()
+  return trimmedValue ? trimmedValue : undefined
+}
+
+function createDefaultPostImage(): PostImage {
+  return {
     original: '/images/image-default.jpg',
   }
+}
 
-  if (!post) {
-    return images
+function formateImageApiDataToPostImage(
+  imageApiData: HeroImage['imageApiData']
+): PostImage | undefined {
+  const parsedImageApiData = parseImageApiData(imageApiData)
+
+  if (!parsedImageApiData) {
+    return undefined
   }
 
-  const { heroImage } = post
-  const imageApiData = parseImageApiData(heroImage?.imageApiData)
-  if (imageApiData) {
-    const w1600 = imageApiData.w1600?.url || imageApiData.w1200?.url
-    const w800 = imageApiData.w800?.url || imageApiData.w480?.url
-    const original = imageApiData.original?.url || imageApiData.url
+  const images = createDefaultPostImage()
+  const original =
+    toNonEmptyString(parsedImageApiData.original?.url) ??
+    toNonEmptyString(parsedImageApiData.url)
+  const w1600 =
+    toNonEmptyString(parsedImageApiData.w1600?.url) ??
+    toNonEmptyString(parsedImageApiData.w1200?.url)
+  const w800 =
+    toNonEmptyString(parsedImageApiData.w800?.url) ??
+    toNonEmptyString(parsedImageApiData.w480?.url)
+  const w2400 = toNonEmptyString(parsedImageApiData.w2400?.url)
+  const w400 = toNonEmptyString(parsedImageApiData.w480?.url)
 
-    if (original) images.original = original
-    if (original) images.w3200 = original
-    if (imageApiData.w2400?.url) images.w2400 = imageApiData.w2400.url
-    if (w1600) images.w1600 = w1600
-    if (w800) images.w800 = w800
-    if (imageApiData.w480?.url) images.w400 = imageApiData.w480.url
+  if (original) {
+    images.original = original
+    images.w3200 = original
+  }
+  if (w2400) {
+    images.w2400 = w2400
+  }
+  if (w1600) {
+    images.w1600 = w1600
+  }
+  if (w800) {
+    images.w800 = w800
+  }
+  if (w400) {
+    images.w400 = w400
   }
 
   return images
 }
 
-// Legacy image format types for backward compatibility
-type LegacyImageFormat = {
-  urlOriginal?: string
-  urlDesktopSized?: string
-  urlTabletSized?: string
-  urlMobileSized?: string
-  urlTinySized?: string
+function formateK6HeroImage(heroImage: K6FlatHeroImage): PostImage {
+  const images = createDefaultPostImage()
+  const original =
+    toNonEmptyString(heroImage.original) ??
+    toNonEmptyString(heroImage.w2400) ??
+    toNonEmptyString(heroImage.w1600) ??
+    toNonEmptyString(heroImage.w1200) ??
+    toNonEmptyString(heroImage.w800) ??
+    toNonEmptyString(heroImage.w480)
+  const w2400 = toNonEmptyString(heroImage.w2400)
+  const w1600 =
+    toNonEmptyString(heroImage.w1600) ?? toNonEmptyString(heroImage.w1200)
+  const w800 = toNonEmptyString(heroImage.w800)
+  const w400 = toNonEmptyString(heroImage.w480)
+
+  if (original) {
+    images.original = original
+    images.w3200 = original
+  }
+  if (w2400) {
+    images.w2400 = w2400
+  }
+  if (w1600) {
+    images.w1600 = w1600
+  }
+  if (w800) {
+    images.w800 = w800
+  }
+  if (w400) {
+    images.w400 = w400
+  }
+
+  return images
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function isLegacyHeroImage(heroImage: unknown): heroImage is HeroImage {
+  return (
+    isRecord(heroImage) &&
+    ('urlOriginal' in heroImage ||
+      'urlDesktopSized' in heroImage ||
+      'urlMobileSized' in heroImage ||
+      'urlTabletSized' in heroImage ||
+      'urlTinySized' in heroImage)
+  )
+}
+
+function isK6NestedHeroImage(
+  heroImage: unknown
+): heroImage is K6NestedHeroImage {
+  return isRecord(heroImage) && 'resized' in heroImage
+}
+
+function isK6FlatHeroImage(heroImage: unknown): heroImage is K6FlatHeroImage {
+  return (
+    isRecord(heroImage) &&
+    ('w480' in heroImage ||
+      'w800' in heroImage ||
+      'w1200' in heroImage ||
+      'w1600' in heroImage ||
+      'w2400' in heroImage ||
+      'original' in heroImage)
+  )
+}
+
+function formatePostImage(post: Post | Topic): PostImage {
+  if (!post) {
+    return createDefaultPostImage()
+  }
+
+  const imageApiData =
+    post.heroImage &&
+    isRecord(post.heroImage) &&
+    'imageApiData' in post.heroImage
+      ? post.heroImage.imageApiData
+      : undefined
+
+  return (
+    formateImageApiDataToPostImage(imageApiData) ?? createDefaultPostImage()
+  )
 }
 
 function formateHeroImage(
-  heroImage:
-    | HeroImage
-    | null
-    | undefined
-    | LegacyImageFormat
-    | Record<string, never>
+  heroImage: FormattableHeroImage | Record<string, never>
 ) {
-  const images: PostImage = {
-    original: '/images/image-default.jpg',
-  }
-
-  // Handle null or empty object
   if (
     !heroImage ||
     (typeof heroImage === 'object' && Object.keys(heroImage).length === 0)
   ) {
-    return images
+    return createDefaultPostImage()
   }
 
-  // Check if it's a legacy format (has urlOriginal, urlDesktopSized, etc.)
-  if (
-    'urlOriginal' in heroImage ||
-    'urlDesktopSized' in heroImage ||
-    'urlMobileSized' in heroImage ||
-    'urlTabletSized' in heroImage ||
-    'urlTinySized' in heroImage
-  ) {
-    const legacy = heroImage as LegacyImageFormat
-    if (legacy.urlOriginal) {
-      images.original = legacy.urlOriginal
-      images.w3200 = legacy.urlOriginal
+  if (isLegacyHeroImage(heroImage)) {
+    const images = createDefaultPostImage()
+    const original = toNonEmptyString(heroImage.urlOriginal)
+    const w2400 = toNonEmptyString(heroImage.urlDesktopSized)
+    const w1600 = toNonEmptyString(heroImage.urlTabletSized)
+    const w800 = toNonEmptyString(heroImage.urlMobileSized)
+    const w400 = toNonEmptyString(heroImage.urlTinySized)
+
+    if (original) {
+      images.original = original
+      images.w3200 = original
     }
-    if (legacy.urlDesktopSized) images.w2400 = legacy.urlDesktopSized
-    if (legacy.urlTabletSized) images.w1600 = legacy.urlTabletSized
-    if (legacy.urlMobileSized) images.w800 = legacy.urlMobileSized
-    if (legacy.urlTinySized) images.w400 = legacy.urlTinySized
+    if (w2400) {
+      images.w2400 = w2400
+    }
+    if (w1600) {
+      images.w1600 = w1600
+    }
+    if (w800) {
+      images.w800 = w800
+    }
+    if (w400) {
+      images.w400 = w400
+    }
+
     return images
   }
 
-  // Handle new format with imageApiData
-  const imageApiData = parseImageApiData(
-    'imageApiData' in heroImage && (heroImage as HeroImage).imageApiData
-      ? (heroImage as HeroImage).imageApiData
-      : undefined
-  )
-  if (imageApiData) {
-    const w1600 = imageApiData.w1600?.url || imageApiData.w1200?.url
-    const w800 = imageApiData.w800?.url || imageApiData.w480?.url
-    const original = imageApiData.original?.url || imageApiData.url
-
-    if (original) images.original = original
-    if (original) images.w3200 = original
-    if (imageApiData.w2400?.url) images.w2400 = imageApiData.w2400.url
-    if (w1600) images.w1600 = w1600
-    if (w800) images.w800 = w800
-    if (imageApiData.w480?.url) images.w400 = imageApiData.w480.url
+  if (isK6NestedHeroImage(heroImage)) {
+    return formateK6HeroImage(heroImage.resized ?? {})
   }
 
-  return images
+  if (isK6FlatHeroImage(heroImage)) {
+    return formateK6HeroImage(heroImage)
+  }
+
+  const images = formateImageApiDataToPostImage(
+    'imageApiData' in heroImage ? heroImage.imageApiData : undefined
+  )
+
+  return images ?? createDefaultPostImage()
 }
 
 const getHeroImageOfAmp = (heroImage: PostImage): string => {

--- a/packages/mirror-tv-next/utils/post-handler.ts
+++ b/packages/mirror-tv-next/utils/post-handler.ts
@@ -1,7 +1,7 @@
 import { formateHeroImage } from './image-handler'
 import type { PostImage } from '~/utils/image-handler'
-import { type HeroImage } from '~/types/common'
 import type { ApiData } from '~/types/api-data'
+import type { FormattableHeroImage } from '~/types/hero-image'
 
 export type FormattedPostCard = {
   href: string
@@ -23,21 +23,12 @@ export type FormattedPostCardJson = Omit<
   label?: string | null
 }
 
-// Legacy image format for backward compatibility
-type LegacyImageFormat = {
-  urlOriginal?: string
-  urlDesktopSized?: string
-  urlTabletSized?: string
-  urlMobileSized?: string
-  urlTinySized?: string
-}
-
 type FormatArticleCardInput = {
   slug: string
   name: string
   publishTime: string | Date
-  heroImage?: HeroImage | LegacyImageFormat | null
-  ogImage?: HeroImage | LegacyImageFormat | null
+  heroImage?: FormattableHeroImage
+  ogImage?: FormattableHeroImage
   thumbnail?: string | null
   images?: PostImage | null
   style?: string | null
@@ -67,12 +58,9 @@ const formatArticleCard = (
     exclusive: 'exclusive' in post ? post.exclusive ?? false : false,
   }
 
-  // Handle legacy image format - convert to HeroImage format if needed
-  let heroImageForFormatting: HeroImage | LegacyImageFormat | null | undefined =
+  let heroImageForFormatting: FormattableHeroImage =
     postFormatArticleCardInput.heroImage ?? postFormatArticleCardInput.ogImage
 
-  // If it's a legacy format (has urlOriginal, urlDesktopSized, etc.), pass it as-is
-  // formateHeroImage can handle both formats
   if (!heroImageForFormatting && postFormatArticleCardInput.thumbnail) {
     heroImageForFormatting = {
       imageApiData: {


### PR DESCRIPTION
This PR addresses missing hero images resulting from the backend API's transition from K5 to K6 formats. It introduces robust, centralized image formatting utilities to handle the various structural formats (Legacy, K6 Flat, K6 Nested) returned by different endpoints. By standardizing the types using `FormattableHeroImage` and shifting parsing logic into `utils/image-handler.ts`, we eliminate several redundant conversion functions scattered throughout the data-fetching actions. Additionally, this PR fixes a styling issue on AMP story pages by ensuring card list images correctly use `object-fit: cover`.

## Additions
- Added `packages/mirror-tv-next/types/hero-image.ts` to define type definitions for K6 image formats (`K6FlatHeroImage`, `K6NestedHeroImage`) and the union type `FormattableHeroImage`.
- Implemented robust type guards and formatting functions (`formateImageApiDataToPostImage`, `formateK6HeroImage`, `isLegacyHeroImage`, `isK6NestedHeroImage`, `isK6FlatHeroImage`) in `utils/image-handler.ts` to process various image structures into a standard `PostImage`.
- Added CSS `.amp-card-list-item-image-image img { object-fit: cover; }` to `pages/story/amp/[slug].tsx` to correct image proportions.

## Removals
- Removed redundant local conversion functions: `convertHeroImageToLegacyFormat` (from `latest-posts-and-editor-choices.tsx` and `topic-video.ts`), `convertPopularPostHeroImage` (from `popular-data.tsx`), and `convertFeaturedHeroImageToLegacy` (from `category/[slug]/page.tsx`).

## Changes
- Updated Zod validation schemas in `latest-posts-and-editor-choices.tsx` (`HeroImageObjectSchema`, `FlexibleHeroImageSchema`) to natively validate and normalize the incoming K6 data formats and added explicit documentation comments.
- Replaced `HeroImage` and localized legacy types with `FormattableHeroImage` across GraphQL fragments (`listing-post.ts`), queries (`editor-choices.ts`, `posts.ts`, `topic.ts`), and global types (`api-data.ts`, `popular-post.ts`, `featured-categories-news.ts`).
- Simplified `formatArticleCard` in `utils/post-handler.ts` to rely on the updated unified `formateHeroImage` function.

## Testing
- Verify that hero images on the homepage (latest posts, editor choices) load correctly.
- Verify that hero images on topic pages and popular posts load correctly.
- Inspect an AMP story page to ensure the images in the related/latest card list are not distorted and apply `object-fit: cover`.

## Screenshots
- N/A

## Todos
- N/A

## Task Links
[熱門影音（popular-videonews-list）縮圖無法顯示 - Asana](https://app.asana.com/1/614399484723017/project/1210724947067404/task/1213756626792925?focus=true)
[【電視amp】修正amp頁熱門新聞、即時新聞預覽縮圖裁切邏輯 - Asana](https://app.asana.com/1/614399484723017/project/1210724947067404/task/1213072338656594?focus=true)
