### PR TITLE
fix(mirror-tv-next): fix story page slideshow image display and refactor remote patterns

### DIFF
--- a/packages/mirror-tv-next/next.config.js
+++ b/packages/mirror-tv-next/next.config.js
@@ -1,53 +1,37 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const path = require('path')
 
+const mnewsImageHostnames = [
+  'v3.mnews.tw',
+  'www.mnews.tw',
+  'staging.mnews.tw',
+  'dev.mnews.tw',
+  'storage.googleapis.com',
+  'statics.mnews.tw',
+  'statics-staging.mnews.tw',
+  'statics-dev.mnews.tw',
+]
+
+const externalImageHostnames = [
+  'www.mirrormedia.mg',
+  'www.mirrormedia.com.tw',
+  'v3-statics.mirrormedia.mg',
+  'v3-statics-staging.mirrormedia.mg',
+  'v3-statics-dev.mirrormedia.mg',
+]
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: false,
   swcMinify: true,
   images: {
-    remotePatterns: [
-      {
+    remotePatterns: [...mnewsImageHostnames, ...externalImageHostnames].map(
+      (hostname) => ({
         protocol: 'https',
-        hostname: 'www.mirrormedia.mg',
+        hostname,
         pathname: '/**',
-      },
-      {
-        protocol: 'https',
-        hostname: 'www.mnews.tw',
-        pathname: '/**',
-      },
-      {
-        protocol: 'https',
-        hostname: 'dev.mnews.tw',
-        pathname: '/**',
-      },
-      {
-        protocol: 'https',
-        hostname: 'staging.mnews.tw',
-        pathname: '/**',
-      },
-      {
-        protocol: 'https',
-        hostname: 'storage.googleapis.com',
-        pathname: '/**',
-      },
-      {
-        protocol: 'https',
-        hostname: 'statics.mnews.tw',
-        pathname: '/**',
-      },
-      {
-        protocol: 'https',
-        hostname: 'v3-statics.mirrormedia.mg',
-        pathname: '/**',
-      },
-      {
-        protocol: 'https',
-        hostname: 'v3-statics-dev.mirrormedia.mg',
-        pathname: '/**',
-      },
-    ],
+      })
+    ),
   },
   output: 'standalone',
   async headers() {


### PR DESCRIPTION
This PR resolves an issue where slideshow images on the story page were failing to load due to missing hostnames in Next.js image configuration. It also refactors the `remotePatterns` setup in `next.config.js` to improve readability and maintainability across different environments (dev, staging, prod).

## Additions
- Added `mnewsImageHostnames` and `externalImageHostnames` constants to store allowed image domains.
- Included missing hostnames: `v3.mnews.tw`, `statics-staging.mnews.tw`, `statics-dev.mnews.tw`, and `v3-statics-staging.mirrormedia.mg`.

## Removals
- Removed hardcoded, repetitive `remotePatterns` objects from the main configuration.

## Changes
- Refactored `images.remotePatterns` to programmatically generate the configuration using a `map` function from consolidated hostname lists.

## Testing
- Verified that slideshow images on the story page load correctly in development and staging environments.
- Ensured `next.config.js` is valid and the server starts without image-related errors.

## Screenshots
- N/A

## Todos
- N/A

## Task Links
[前端-全站縮圖改抓webp - Asana](https://app.asana.com/1/614399484723017/project/1210724947067404/task/1213756626792927?focus=true)