### PR TITLE
fix: resolve homepage "load more" hang

### DIFF
--- a/packages/mirror-tv-next/app/_actions/homepage/latest-posts-and-editor-choices.tsx
+++ b/packages/mirror-tv-next/app/_actions/homepage/latest-posts-and-editor-choices.tsx
@@ -335,88 +335,101 @@ async function getLatestPostsAndEditorChoices({
         source: 'json',
       } as JsonChainResult
     }
-    data = await createDataFetchingChain<JsonChainResult>(
-      errorLogger,
-      { latest: [], choices: [], source: 'graphql' as const },
-      fetchFromJson as unknown as () => Promise<JsonChainResult>,
-      async (): Promise<JsonChainResult> => {
-        const client = getClient()
 
-        const [editorChoicesResult, latestPostsResult] = await Promise.all([
-          client.query<{
-            allEditorChoices: EditorChoices[]
-          }>({
-            query: fetchEditorChoices,
-          }),
-          client.query<{
-            allPosts: PostWithCategory[]
-            _allPostsMeta?: { count: number }
-          }>({
-            query: getPostsWithCategory,
-            variables: {
-              first,
-              skip,
-              withCount,
-              filteredSlug,
-            },
-          }),
-        ])
+    const fetchFromGraphQL = async (): Promise<JsonChainResult> => {
+      const client = getClient()
 
-        const editorChoicesValidation =
-          GraphQLEditorChoicesResponseSchema.safeParse(editorChoicesResult.data)
-        const latestPostsValidation =
-          GraphQLLatestPostsResponseSchema.safeParse(latestPostsResult.data)
+      const [editorChoicesResult, latestPostsResult] = await Promise.all([
+        client.query<{
+          allEditorChoices: EditorChoices[]
+        }>({
+          query: fetchEditorChoices,
+        }),
+        client.query<{
+          allPosts: PostWithCategory[]
+          _allPostsMeta?: { count: number }
+        }>({
+          query: getPostsWithCategory,
+          variables: {
+            first,
+            skip,
+            withCount,
+            filteredSlug,
+          },
+        }),
+      ])
 
-        if (!editorChoicesValidation.success) {
-          throw new Error(
-            `GraphQL EditorChoices validation failed: ${JSON.stringify(
-              editorChoicesValidation.error.issues
-            )}`
-          )
-        }
-        if (!latestPostsValidation.success) {
-          throw new Error(
-            `GraphQL LatestPosts validation failed: ${JSON.stringify(
-              latestPostsValidation.error.issues
-            )}`
-          )
-        }
+      const editorChoicesValidation =
+        GraphQLEditorChoicesResponseSchema.safeParse(editorChoicesResult.data)
+      const latestPostsValidation = GraphQLLatestPostsResponseSchema.safeParse(
+        latestPostsResult.data
+      )
 
-        const validatedEditorChoices = editorChoicesValidation.data
-        const validatedLatestPosts = latestPostsValidation.data
+      if (!editorChoicesValidation.success) {
+        throw new Error(
+          `GraphQL EditorChoices validation failed: ${JSON.stringify(
+            editorChoicesValidation.error.issues
+          )}`
+        )
+      }
+      if (!latestPostsValidation.success) {
+        throw new Error(
+          `GraphQL LatestPosts validation failed: ${JSON.stringify(
+            latestPostsValidation.error.issues
+          )}`
+        )
+      }
 
-        const transformedGraphQLChoices =
-          validatedEditorChoices.allEditorChoices.map((choice) => ({
-            choice: {
-              ...choice.choice,
-              heroImage: choice.choice.heroImage ?? null,
-              heroVideo: choice.choice.heroVideo
-                ? {
-                    coverPhoto: choice.choice.heroVideo.coverPhoto ?? null,
-                  }
-                : null,
-            },
-          }))
+      const validatedEditorChoices = editorChoicesValidation.data
+      const validatedLatestPosts = latestPostsValidation.data
 
-        const transformedGraphQLPosts = validatedLatestPosts.allPosts.map(
-          (post) => ({
-            ...post,
-            heroVideo: post.heroVideo
+      const transformedGraphQLChoices =
+        validatedEditorChoices.allEditorChoices.map((choice) => ({
+          choice: {
+            ...choice.choice,
+            heroImage: choice.choice.heroImage ?? null,
+            heroVideo: choice.choice.heroVideo
               ? {
-                  coverPhoto: post.heroVideo.coverPhoto ?? null,
+                  coverPhoto: choice.choice.heroVideo.coverPhoto ?? null,
                 }
               : null,
-          })
-        )
+          },
+        }))
 
-        return {
-          latest: transformedGraphQLPosts as PostWithCategory[],
-          choices: transformedGraphQLChoices as EditorChoices[],
-          _allPostsMeta: validatedLatestPosts._allPostsMeta,
-          source: 'graphql' as const,
-        } as JsonChainResult
+      const transformedGraphQLPosts = validatedLatestPosts.allPosts.map(
+        (post) => ({
+          ...post,
+          heroVideo: post.heroVideo
+            ? {
+                coverPhoto: post.heroVideo.coverPhoto ?? null,
+              }
+            : null,
+        })
+      )
+
+      return {
+        latest: transformedGraphQLPosts as PostWithCategory[],
+        choices: transformedGraphQLChoices as EditorChoices[],
+        _allPostsMeta: validatedLatestPosts._allPostsMeta,
+        source: 'graphql' as const,
+      } as JsonChainResult
+    }
+
+    if (jsonPage > 1) {
+      try {
+        data = await fetchFromJson()
+      } catch (err) {
+        errorLogger(err)
+        data = { latest: [], choices: [], source: 'json' as const }
       }
-    )
+    } else {
+      data = await createDataFetchingChain<JsonChainResult>(
+        errorLogger,
+        { latest: [], choices: [], source: 'graphql' as const },
+        fetchFromJson as unknown as () => Promise<JsonChainResult>,
+        fetchFromGraphQL
+      )
+    }
   } else {
     const client = getClient()
 

--- a/packages/mirror-tv-next/app/actions-logging.ts
+++ b/packages/mirror-tv-next/app/actions-logging.ts
@@ -21,56 +21,67 @@ export async function logPageView({
   screenSize: { width: number; height: number }
   extra?: Record<string, unknown>
 }) {
-  const logging = new Logging({ projectId: GCP_PROJECT_ID })
-  const eventType = 'page-view'
-  const logName = `${GCP_LOG_NAME_PREFIX}-${ENV}-web-${eventType}`
-  const log = logging.log(logName)
-  const taipeiTime = dayjs().tz('Asia/Taipei')
-  const eventTriggeredDate = taipeiTime.format('YYYY/MM/DD')
-  const eventTriggeredTime = taipeiTime.format('HH:mm')
-  const {
-    browser,
-    device,
-    os,
-    isInAppBrowser,
-    isWebview,
-    ipAddress,
-    pathname,
-  } = parseUserAgentInfo()
-  const { name: browserName, version: browserVersion } = browser
-  const { model: deviceModel, vendor: deviceVendor } = device
-  const { name: osName, version: osVersion } = os
-  const pageType = parsePageType(pathname)
-  const metadata = {
-    resource: { type: 'global' },
-    severity: 'INFO',
-    labels: {
-      eventType,
-      date: eventTriggeredDate,
-      time: eventTriggeredTime,
-      browserName,
-      browserVersion,
-      deviceModel,
-      deviceVendor,
-      osName,
-      osVersion,
+  if (
+    process.env.NODE_ENV === 'development' &&
+    !process.env.GOOGLE_APPLICATION_CREDENTIALS
+  ) {
+    return
+  }
+
+  try {
+    const logging = new Logging({ projectId: GCP_PROJECT_ID })
+    const eventType = 'page-view'
+    const logName = `${GCP_LOG_NAME_PREFIX}-${ENV}-web-${eventType}`
+    const log = logging.log(logName)
+    const taipeiTime = dayjs().tz('Asia/Taipei')
+    const eventTriggeredDate = taipeiTime.format('YYYY/MM/DD')
+    const eventTriggeredTime = taipeiTime.format('HH:mm')
+    const {
+      browser,
+      device,
+      os,
+      isInAppBrowser,
+      isWebview,
       ipAddress,
-      referrer,
-    },
+      pathname,
+    } = parseUserAgentInfo()
+    const { name: browserName, version: browserVersion } = browser
+    const { model: deviceModel, vendor: deviceVendor } = device
+    const { name: osName, version: osVersion } = os
+    const pageType = parsePageType(pathname)
+    const metadata = {
+      resource: { type: 'global' },
+      severity: 'INFO',
+      labels: {
+        eventType,
+        date: eventTriggeredDate,
+        time: eventTriggeredTime,
+        browserName,
+        browserVersion,
+        deviceModel,
+        deviceVendor,
+        osName,
+        osVersion,
+        ipAddress,
+        referrer,
+      },
+    }
+
+    const jsonPayload = {
+      pageURL: pathname,
+      pageType,
+      screenSize,
+      isInAppBrowser,
+      isWebview,
+      extra,
+    }
+
+    const entry = log.entry(metadata, jsonPayload)
+
+    await log.write(entry)
+  } catch (err) {
+    console.error('[logPageView] failed', err)
   }
-
-  const jsonPayload = {
-    pageURL: pathname,
-    pageType,
-    screenSize,
-    isInAppBrowser,
-    isWebview,
-    extra,
-  }
-
-  const entry = log.entry(metadata, jsonPayload)
-
-  return log.write(entry)
 }
 
 function parsePageType(url: string) {

--- a/packages/mirror-tv-next/components/homepage/post-list-with-first-page.tsx
+++ b/packages/mirror-tv-next/components/homepage/post-list-with-first-page.tsx
@@ -60,7 +60,7 @@ export default function PostListWithFirstPage({
             (post) => !existingSlugs.has(post.slug)
           )
           setJsonPosts((prevPosts) => {
-            return [...newPosts, ...prevPosts]
+            return [...prevPosts, ...newPosts]
           })
           return newPosts
         }

--- a/packages/mirror-tv-next/components/homepage/post-list-with-first-page.tsx
+++ b/packages/mirror-tv-next/components/homepage/post-list-with-first-page.tsx
@@ -25,43 +25,67 @@ export default function PostListWithFirstPage({
   const [jsonPosts, setJsonPosts] = useState<FormattedPostCard[]>(initPosts)
   const [hasShowSecondPage, setHasShowSecondPage] = useState(false)
   const fetchMorePosts = async (page: number) => {
-    if (source === 'json') {
-      const postsResponse = await getLatestPostsAndEditorChoices({
-        first: HOMEPAGE_POSTS_PAGE_SIZE,
-        skip: 0,
-        withCount: false,
-        filteredSlug: filteredSlug,
-        jsonPage: page,
+    const withTimeout = <T,>(p: Promise<T>, label: string): Promise<T> => {
+      let timer: ReturnType<typeof setTimeout> | undefined
+      const timeout = new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+          reject(new Error(`[homepage latest] timeout at ${label}`))
+        }, 5000)
       })
-
-      const additionalPosts =
-        postsResponse?.data?.latest?.map((post) => formatArticleCard(post)) ||
-        []
-
-      if (additionalPosts.length > 0) {
-        const existingSlugs = new Set(jsonPosts.map((post) => post.slug))
-        const newPosts = additionalPosts.filter(
-          (post) => !existingSlugs.has(post.slug)
-        )
-        setJsonPosts((prevPosts) => {
-          return [...newPosts, ...prevPosts]
-        })
-        return newPosts
-      }
-
-      return []
+      return Promise.race([p, timeout]).finally(() => {
+        if (timer) clearTimeout(timer)
+      }) as Promise<T>
     }
 
-    const postsResponse = await getLatestPostsAndEditorChoices({
-      first: HOMEPAGE_POSTS_PAGE_SIZE,
-      skip: HOMEPAGE_POSTS_PAGE_SIZE * (page - 1) - renderedSalesLength,
-      withCount: false,
-      filteredSlug: filteredSlug,
-      jsonPage: 0,
-    })
-    return (
-      postsResponse?.data?.latest?.map((post) => formatArticleCard(post)) || []
-    )
+    try {
+      if (source === 'json') {
+        const postsResponse = await withTimeout(
+          getLatestPostsAndEditorChoices({
+            first: HOMEPAGE_POSTS_PAGE_SIZE,
+            skip: 0,
+            withCount: false,
+            filteredSlug: filteredSlug,
+            jsonPage: page,
+          }),
+          'json-branch'
+        )
+
+        const additionalPosts =
+          postsResponse?.data?.latest?.map((post) => formatArticleCard(post)) ||
+          []
+
+        if (additionalPosts.length > 0) {
+          const existingSlugs = new Set(jsonPosts.map((post) => post.slug))
+          const newPosts = additionalPosts.filter(
+            (post) => !existingSlugs.has(post.slug)
+          )
+          setJsonPosts((prevPosts) => {
+            return [...newPosts, ...prevPosts]
+          })
+          return newPosts
+        }
+
+        return []
+      }
+
+      const postsResponse = await withTimeout(
+        getLatestPostsAndEditorChoices({
+          first: HOMEPAGE_POSTS_PAGE_SIZE,
+          skip: HOMEPAGE_POSTS_PAGE_SIZE * (page - 1) - renderedSalesLength,
+          withCount: false,
+          filteredSlug: filteredSlug,
+          jsonPage: 0,
+        }),
+        'graphql-branch'
+      )
+
+      return (
+        postsResponse?.data?.latest?.map((post) => formatArticleCard(post)) ||
+        []
+      )
+    } catch (err) {
+      return []
+    }
   }
 
   return (

--- a/packages/mirror-tv-next/components/page-logger.tsx
+++ b/packages/mirror-tv-next/components/page-logger.tsx
@@ -33,7 +33,9 @@ export default function PageLogger({
       })
     }
 
-    log()
+    void log().catch((err) => {
+      console.error('[PageLogger] failed to log page view', err)
+    })
   }, [clientReferrer, currentUrl, extra, initialReferrer, screenSize])
 
   return null


### PR DESCRIPTION
- Add try/catch and await to `logPageView` to prevent uncaughtExceptions from hanging the server action runtime.
- Implement development-only guard in `logPageView` to skip GCP logging when credentials are missing.
- Add client-side `.catch()` in `PageLogger` and timeout protection in `PostListWithFirstPage` for defense in depth.
- Refine JSON pagination logic to prevent incorrect GraphQL fallback on load-more pages.