### PR TITLE
fix(mirror-tv-next): decompress gzip-encoded JSON read from GCS Fuse

### DIFF
--- a/packages/mirror-tv-next/utils/fetch-static-json.ts
+++ b/packages/mirror-tv-next/utils/fetch-static-json.ts
@@ -38,6 +38,7 @@ export async function fetchStaticJson<T = unknown>(
     // Structure: [mount_dir]/[prefix]/[filename]
     const filePath = `${GCS_FUSE_MOUNT_DIR}${pathPrefix}/${filename}`
 
+    let phase: 'read' | 'gunzip' | 'parse' = 'read'
     let decompressed = false
     try {
       const buffer = await fs.readFile(filePath)
@@ -47,12 +48,14 @@ export async function fetchStaticJson<T = unknown>(
         buffer[1] === GZIP_MAGIC_1
       let content: string
       if (isGzip) {
+        phase = 'gunzip'
         const inflated = await gunzip(buffer)
         decompressed = true
         content = inflated.toString('utf-8')
       } else {
         content = buffer.toString('utf-8')
       }
+      phase = 'parse'
       return JSON.parse(content) as T
     } catch (err) {
       const nodeErr = err as NodeJS.ErrnoException
@@ -67,6 +70,7 @@ export async function fetchStaticJson<T = unknown>(
           filePath,
           mountDir: GCS_FUSE_MOUNT_DIR,
           cacheBust,
+          phase,
           decompressed,
           error:
             err instanceof Error

--- a/packages/mirror-tv-next/utils/fetch-static-json.ts
+++ b/packages/mirror-tv-next/utils/fetch-static-json.ts
@@ -1,8 +1,20 @@
 import fs from 'fs/promises'
+import zlib from 'zlib'
+import { promisify } from 'util'
 import { STATIC_BASE_URL } from '~/constants/endpoint-config'
 import { GLOBAL_CACHE_SETTING } from '~/constants/environment-variables'
 import { isServer } from '~/utils/common'
 import { appendTimestampForCache } from '~/utils/url'
+
+const gunzip = promisify(zlib.gunzip)
+
+// GCS objects uploaded with `Content-Encoding: gzip` are stored as compressed
+// bytes; GCS Fuse exposes raw bytes (no transparent decode), so we sniff the
+// gzip magic header (RFC 1952) and gunzip when present. The bucket contains a
+// mix of gzipped and plain JSON files, so unconditional decompression would
+// break the plain ones.
+const GZIP_MAGIC_0 = 0x1f
+const GZIP_MAGIC_1 = 0x8b
 
 type FetchStaticJsonOptions = {
   pathPrefix?: '/json' | '/files/json' | '/files/documents'
@@ -26,15 +38,24 @@ export async function fetchStaticJson<T = unknown>(
     // Structure: [mount_dir]/[prefix]/[filename]
     const filePath = `${GCS_FUSE_MOUNT_DIR}${pathPrefix}/${filename}`
 
+    let decompressed = false
     try {
-      const content = await fs.readFile(filePath, 'utf-8')
+      const buffer = await fs.readFile(filePath)
+      const isGzip =
+        buffer.length >= 2 &&
+        buffer[0] === GZIP_MAGIC_0 &&
+        buffer[1] === GZIP_MAGIC_1
+      let content: string
+      if (isGzip) {
+        const inflated = await gunzip(buffer)
+        decompressed = true
+        content = inflated.toString('utf-8')
+      } else {
+        content = buffer.toString('utf-8')
+      }
       return JSON.parse(content) as T
     } catch (err) {
-      const isError = err instanceof Error;
-  
-      // 透過轉型取得 Node.js 專有的屬性
-      // 我們先將其視為 any 或特定的 NodeJS.ErrnoException
-      const nodeErr = err as NodeJS.ErrnoException;
+      const nodeErr = err as NodeJS.ErrnoException
       // Fallback to fetch if file not found or unreadable
       console.warn(
         JSON.stringify({
@@ -46,15 +67,16 @@ export async function fetchStaticJson<T = unknown>(
           filePath,
           mountDir: GCS_FUSE_MOUNT_DIR,
           cacheBust,
+          decompressed,
           error:
             err instanceof Error
               ? {
-            name: nodeErr.name, 
-            message: nodeErr.message, 
-            code: nodeErr.code,       // 現在認得到了
-            errno: nodeErr.errno,     // 系統錯誤編號
-            syscall: nodeErr.syscall, // 發生錯誤的系統呼叫
-              }
+                  name: nodeErr.name,
+                  message: nodeErr.message,
+                  code: nodeErr.code,
+                  errno: nodeErr.errno,
+                  syscall: nodeErr.syscall,
+                }
               : String(err),
         })
       )


### PR DESCRIPTION
## Summary

- GCS Fuse mount path 每次讀 JSON 失敗，導致前端持續 fallback 到 GraphQL，違反「GCS 為主、GraphQL 為備援」的設計初衷
- 根因：bucket 內多數 JSON 物件以 `Content-Encoding: gzip` 上傳，HTTP 路徑（Apollo / fetch）會自動解壓，但 GCS Fuse 不解析 metadata、暴露的是壓縮後 raw bytes，`fs.readFile + JSON.parse` 看到 gzip magic 直接 `SyntaxError`
- 修法：偵測 RFC 1952 gzip magic header（`0x1f 0x8b`）才走 `zlib.gunzip`，其餘檔案維持純 JSON 路徑，因為 bucket 實際是混合格式（例如 `popularlist.json` 沒有 `Content-Encoding`）

對應 Asana 卡片：[【電視Web】GCS mount前端新增解gzip套件](https://app.asana.com/1/614399484723017/project/1210724947067404/task/1214282158257680)

## 關聯證據

| 來源 | 內容 |
|---|---|
| Production log | `[fetchStaticJson] Local read failed`, `Unexpected token ''... is not valid JSON`（`` 是 gzip magic 第一個 byte） |
| GCS metadata | `header.json` / `flash_news.json` / `latest_posts0[1-4].json` / `weather.json` / `topic.json` 皆有 `content_encoding: gzip` |
| Magic bytes | `gcloud storage cat ... \| xxd` → `1f8b 0800 ...` |

## Test plan

- [x] `yarn build` 通過、TypeScript 無 error
- [x] Local dev server 配 sample mount（11 gzipped + 2 plain JSON 檔），首頁渲染後 terminal **0 個** `[fetchStaticJson] Local read failed` WARNING
- [x] Edge cases（端對端 Node 驗證）：
  - gzip valid → `decompressed=true`、parse 成功
  - plain JSON → `decompressed=false`、parse 成功
  - corrupt gzip（截斷至 8 bytes） → `Z_BUF_ERROR` 被 catch、走既有 fallback 路徑
  - empty file → `SyntaxError` 被 catch、走 fallback
  - nonexistent file → `ENOENT` 被 catch、走 fallback
- [ ] Reviewer 驗證 dev 部署後，於 Cloud Run log 確認 `fetchStaticJson` WARNING 大量減少：
  ```
  gcloud logging read 'resource.type="cloud_run_revision"
    AND resource.labels.service_name="tabris-mirror-tv-next-dev-k6"
    AND severity="WARNING"
    AND jsonPayload.message:"fetchStaticJson"' \
    --project mirror-tv-275709 --freshness=30m --limit 20
  ```

## 不在範圍內

- 寫入端（`data-services-daily`、`Lilith`）的 gzip 寫入策略不動
- bucket 內混合格式不做統一化（讀取端做格式偵測即可容忍）
- `createDataFetchingChain` / `apollo-client` / HTTP fallback URL 不動

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214527341014419