### PR TITLE
feat: complete SOT thumbnail coverage with object-fit contain and black background

### DIFF
--- a/packages/mirror-tv-next/components/category/_styles/ui-feature-post.module.scss
+++ b/packages/mirror-tv-next/components/category/_styles/ui-feature-post.module.scss
@@ -23,6 +23,7 @@
   width: 100%;
   padding-top: 44.435556%;
   position: relative;
+  background-color: black;
   @include media-breakpoint-up(xl) {
     min-width: calc((2 / 3) * 100%);
     overflow: hidden;

--- a/packages/mirror-tv-next/components/category/posts-list-manager.tsx
+++ b/packages/mirror-tv-next/components/category/posts-list-manager.tsx
@@ -158,6 +158,7 @@ export default function CategoryPostsListManager({
                       label={postItem.label ?? ''}
                       mobileLayoutDirection="row"
                       exclusive={postItem.exclusive ?? false}
+                      slug={postItem.slug}
                     />
                   </li>
                 )

--- a/packages/mirror-tv-next/components/category/ui-feature-post.tsx
+++ b/packages/mirror-tv-next/components/category/ui-feature-post.tsx
@@ -9,7 +9,16 @@ type UiFeaturePostProps = {
 }
 
 export default function UiFeaturePost({ post }: UiFeaturePostProps) {
-  const { href, style, name, images, imagesWebP, publishTime, exclusive } = post
+  const {
+    href,
+    style,
+    name,
+    images,
+    imagesWebP,
+    publishTime,
+    exclusive,
+    slug,
+  } = post
 
   return (
     <a
@@ -29,6 +38,7 @@ export default function UiFeaturePost({ post }: UiFeaturePostProps) {
           rwd={{ mobile: '500px', tablet: '500px', desktop: '500px' }}
           priority={false}
           imgClassName="article-img"
+          slug={slug}
         />
         {exclusive && <UiExclusiveMark />}
         {style === 'videoNews' && <span className={styles.videoIcon}></span>}

--- a/packages/mirror-tv-next/components/category/video/_styles/editor-choice-video-list.module.scss
+++ b/packages/mirror-tv-next/components/category/video/_styles/editor-choice-video-list.module.scss
@@ -115,6 +115,7 @@
     max-width: 120px;
     height: 80px;
     position: relative;
+    background-color: black;
   }
   span {
     flex: 1;

--- a/packages/mirror-tv-next/components/category/video/_styles/video-post-card.module.scss
+++ b/packages/mirror-tv-next/components/category/video/_styles/video-post-card.module.scss
@@ -24,6 +24,7 @@
     padding-top: calc(9 / 16 * 100%);
     position: relative;
     overflow: hidden;
+    background-color: black;
     @include media-breakpoint-up(md) {
       padding-top: calc(121.5px / 216px * 100%);
     }

--- a/packages/mirror-tv-next/components/category/video/editor-choice-video-list.tsx
+++ b/packages/mirror-tv-next/components/category/video/editor-choice-video-list.tsx
@@ -87,6 +87,7 @@ export default function EditorChoiceVideoList({
                         desktop: '500px',
                       }}
                       priority={false}
+                      slug={videoEditor?.slug ?? ''}
                     />
                     <span className={styles.videoIcon}></span>
                   </picture>

--- a/packages/mirror-tv-next/components/category/video/video-post-card.tsx
+++ b/packages/mirror-tv-next/components/category/video/video-post-card.tsx
@@ -9,6 +9,7 @@ type VideoPostCardProps = {
   title: string
   href: string
   exclusive: boolean
+  slug?: string
 }
 
 export default function VideoPostCard({
@@ -17,6 +18,7 @@ export default function VideoPostCard({
   title,
   href,
   exclusive,
+  slug = '',
 }: VideoPostCardProps) {
   return (
     <a
@@ -32,6 +34,7 @@ export default function VideoPostCard({
           alt={title}
           rwd={{ mobile: '500px', tablet: '500px', desktop: '500px' }}
           priority={false}
+          slug={slug}
         />
         {exclusive && <UiExclusiveMark />}
         <span className={styles.videoIcon}></span>

--- a/packages/mirror-tv-next/components/category/video/video-posts-list.tsx
+++ b/packages/mirror-tv-next/components/category/video/video-posts-list.tsx
@@ -138,6 +138,7 @@ export default function VideoPostsList({
                   imageUrlsWebP={post.imagesWebP}
                   href={post.href}
                   exclusive={post.exclusive ?? false}
+                  slug={post.slug}
                 />
               </SwiperSlide>
             )

--- a/packages/mirror-tv-next/components/homepage/_styles/popular-posts-and-weather.module.scss
+++ b/packages/mirror-tv-next/components/homepage/_styles/popular-posts-and-weather.module.scss
@@ -89,6 +89,7 @@
   height: 64px;
   overflow: hidden;
   border-radius: 4px;
+  background-color: black;
 }
 
 .name {

--- a/packages/mirror-tv-next/components/homepage/_styles/ui-post-card-homepage.module.scss
+++ b/packages/mirror-tv-next/components/homepage/_styles/ui-post-card-homepage.module.scss
@@ -27,6 +27,7 @@
     padding-top: 66.66%;
     position: relative;
     border-radius: 4px;
+    background-color: black;
     @include media-breakpoint-up(xl) {
       min-width: 180px;
       min-height: 120px;

--- a/packages/mirror-tv-next/components/homepage/editor-choices-swiper.tsx
+++ b/packages/mirror-tv-next/components/homepage/editor-choices-swiper.tsx
@@ -17,7 +17,7 @@ import {
   Pagination,
 } from 'swiper/modules'
 import Image from '@readr-media/react-image'
-import { formateHeroImage } from '~/utils'
+import { formateHeroImage, getSotThumbnailObjectFit } from '~/utils'
 import { useRef } from 'react'
 import { PaginationOptions } from 'swiper/types'
 import UiExclusiveMark from '../shared/ui-exclusive-mark'
@@ -101,9 +101,7 @@ export default function EditorChoicesSwiper({
                         desktop: '1000px',
                       }}
                       priority={false}
-                      objectFit={
-                        choice.slug.includes('sot') ? 'contain' : 'cover'
-                      }
+                      objectFit={getSotThumbnailObjectFit(choice.slug)}
                     />
                     <a
                       className={`${styles.nameWrapper} GTM-editor-choices-link`}

--- a/packages/mirror-tv-next/components/homepage/popular-posts-and-weather.tsx
+++ b/packages/mirror-tv-next/components/homepage/popular-posts-and-weather.tsx
@@ -3,7 +3,7 @@ import { useData } from '~/context/data-context'
 import styles from './_styles/popular-posts-and-weather.module.scss'
 import Link from 'next/link'
 import UiHeadingBordered from '../shared/ui-heading-bordered'
-import { formateHeroImage } from '~/utils'
+import { formateHeroImage, getSotThumbnailObjectFit } from '~/utils'
 import Image from '@readr-media/react-image'
 import WeatherMain from './weather-main'
 
@@ -49,7 +49,7 @@ export default function PopularPostsList({ title }: PopularPostsListType) {
                       desktop: '1000px',
                     }}
                     priority={false}
-                    objectFit={post.slug.includes('sot') ? 'contain' : 'cover'}
+                    objectFit={getSotThumbnailObjectFit(post.slug)}
                   />
                 </div>
                 <p className={styles.name}>{post.name}</p>

--- a/packages/mirror-tv-next/components/shared/_styles/ui-post-card-aside.module.scss
+++ b/packages/mirror-tv-next/components/shared/_styles/ui-post-card-aside.module.scss
@@ -16,6 +16,7 @@
 
 .image {
   position: relative;
+  background-color: black;
   img {
     position: absolute;
     top: 0;

--- a/packages/mirror-tv-next/components/shared/_styles/ui-post-card.module.scss
+++ b/packages/mirror-tv-next/components/shared/_styles/ui-post-card.module.scss
@@ -25,6 +25,7 @@
     width: 100%;
     padding-top: 66.66%;
     position: relative;
+    background-color: black;
     @include media-breakpoint-up(xl) {
       min-width: 180px;
       min-height: 120px;

--- a/packages/mirror-tv-next/components/shared/responsive-image.tsx
+++ b/packages/mirror-tv-next/components/shared/responsive-image.tsx
@@ -1,6 +1,6 @@
 'use client'
 import Image from '@readr-media/react-image'
-import type { PostImage } from '~/utils'
+import { getSotThumbnailObjectFit, type PostImage } from '~/utils'
 
 type UiPostCardProps = {
   images: PostImage
@@ -43,7 +43,7 @@ export default function ResponsiveImage({
       rwd={rwd}
       priority={priority}
       className={imgClassName}
-      objectFit={slug?.includes('sot') ? 'contain' : 'cover'}
+      objectFit={getSotThumbnailObjectFit(slug)}
     />
   )
 }

--- a/packages/mirror-tv-next/components/shared/ui-post-card.tsx
+++ b/packages/mirror-tv-next/components/shared/ui-post-card.tsx
@@ -18,6 +18,7 @@ export type UiPostCardProps = {
   // Differentiate two usages in / and /category/:name pages
   mobileLayoutDirection: 'row' | 'column'
   postTitleHighlightText?: string
+  slug?: string
 }
 
 export default function UiPostCard({
@@ -32,6 +33,7 @@ export default function UiPostCard({
   label = '',
   exclusive = false,
   priority = false,
+  slug = '',
 }: UiPostCardProps) {
   const isVideoNews = postStyle === 'videoNews'
 
@@ -72,6 +74,7 @@ export default function UiPostCard({
             alt={title}
             rwd={{ mobile: '500px', tablet: '500px', desktop: '500px' }}
             priority={priority}
+            slug={slug}
           />
           {isVideoNews && <span className={styles.videoIcon}></span>}
           {exclusive && label !== SALES_LABEL_NAME && <UiExclusiveMark />}

--- a/packages/mirror-tv-next/components/tag/posts-list-manager.tsx
+++ b/packages/mirror-tv-next/components/tag/posts-list-manager.tsx
@@ -139,6 +139,7 @@ export default function TagPostsListManager({
                     mobileLayoutDirection="column"
                     exclusive={postItem.exclusive ?? false}
                     priority={index === 0}
+                    slug={postItem.slug}
                   />
                 </li>
               ))}

--- a/packages/mirror-tv-next/styles/global.css
+++ b/packages/mirror-tv-next/styles/global.css
@@ -59,6 +59,15 @@ p {
   display: none !important;
 }
 
+/* SOT thumbnails: site-wide safety net for any thumbnail inside an anchor
+ * that links to a SOT story/external post. Covers third-party widgets
+ * (Compass-Fit) and any component that does not pass the slug prop down. */
+a[href*='/story/'][href*='sot'] img,
+a[href*='/external/'][href*='sot'] img {
+  object-fit: contain !important;
+  background-color: black;
+}
+
 /*! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */
 
 /* Document

--- a/packages/mirror-tv-next/utils/index.ts
+++ b/packages/mirror-tv-next/utils/index.ts
@@ -18,6 +18,7 @@ import {
   addMaxWidthToFigureWithStyle,
   removeDuplicateFirstParagraph,
 } from './content-handler'
+import { isSotPost, getSotThumbnailObjectFit } from './post-style'
 
 export {
   extractYoutubeId,
@@ -31,6 +32,8 @@ export {
   doesHaveBrief,
   addMaxWidthToFigureWithStyle,
   removeDuplicateFirstParagraph,
+  isSotPost,
+  getSotThumbnailObjectFit,
 }
 export type {
   FormattedPostCard,

--- a/packages/mirror-tv-next/utils/post-style.ts
+++ b/packages/mirror-tv-next/utils/post-style.ts
@@ -1,0 +1,17 @@
+/**
+ * Post-style decisions driven by post metadata (e.g. slug).
+ *
+ * Centralizes presentation rules that depend on post properties so they
+ * can evolve in one place instead of being duplicated at each call site.
+ */
+
+// SOT (Sound on Tape) posts are auto-imported from YouTube playlists.
+// Their thumbnails are typically 16:9 video stills; using `cover` crops
+// out important content, so we render them with `contain` and rely on
+// the container's black background to letterbox the empty area.
+export const isSotPost = (slug?: string | null): boolean =>
+  slug?.includes('sot') ?? false
+
+export const getSotThumbnailObjectFit = (
+  slug?: string | null
+): 'contain' | 'cover' => (isSotPost(slug) ? 'contain' : 'cover')


### PR DESCRIPTION
## Summary
完成 PM「全站 SOT 縮圖 object-fit: contain + 上下顯示黑色」的需求，補完 PR #533 / #534 / #536 未涵蓋的範圍：

- 抽 `utils/post-style.ts` 把 SOT 判斷集中（取代 3 處 inline 重複邏輯）
- 補 4 個遺漏元件的 `slug` prop（含 caller 鏈）：`shared/ui-post-card`、`category/ui-feature-post`、`category/video/video-post-card`、`category/video/editor-choice-video-list`
- 7 個 SCSS 容器加 `background-color: black`（letterbox 黑底）
- `styles/global.css` 加 site-wide safety net（涵蓋 Compass-Fit 第三方 widget）

相關卡片：
- Asana：[【電視】前端-slug含sot的Post縮圖顯示改 object-fit contain](https://app.asana.com/1/614399484723017/project/1180545429058675/task/1214117836323066)
- 前置 PR：#533、#534、#536（Wendy 已 merge）

## Verification
Local dev 環境（`http://localhost:3000`）逐版位 DOM computed style 量化比對 vs `https://dev.mnews.tw`：

| 頁面 | LOCAL | REMOTE（前置） |
|---|---|---|
| `/category/video` SOT 9 張 | contain + 黑底 ✅ | cover + 透明 ❌ |
| `/story/[sot]` 側欄 SOT 6 張 | contain + 黑底 ✅ | contain + 透明 ❌ |
| 首頁 SOT 2 張 | contain + 黑底 ✅ | contain + 透明 ❌ |
| 所有非 SOT | cover（無回歸）✅ | cover ✅ |