### PR TITLE
feat(topic): sort promote topics by order property

### DIFF
--- a/packages/mirror-tv-next/app/_actions/promote-topic.ts
+++ b/packages/mirror-tv-next/app/_actions/promote-topic.ts
@@ -85,7 +85,9 @@ async function fetchPromoteTopics(): Promise<PromoteTopicData[]> {
   try {
     const rawData = await fetchStaticJson(PROMOTE_TOPICS_FILENAME)
     const data = promoteTopicsSchema.parse(rawData)
-    return normalizePromoteTopics(data.promoteTopics)
+    return normalizePromoteTopics(data.promoteTopics).sort(
+      (a, b) => (a.order ?? Infinity) - (b.order ?? Infinity)
+    )
   } catch (error) {
     errorLogger(error)
     return []


### PR DESCRIPTION
- Implement sorting logic in `fetchPromoteTopics` to arrange topics by their `order` value.
- Ensure topics without an `order` property are appended to the end of the list using `Infinity`.

## Task Links
[前端-全站右側新增promote topic區塊 - Asana](https://app.asana.com/1/614399484723017/project/1214101852573966/task/1213905694361982?focus=true)