### PR TITLE
fix: apply preview-server basePath to story/external public assets

### DIFF
--- a/packages/mirror-tv-next/components/layout/footer.tsx
+++ b/packages/mirror-tv-next/components/layout/footer.tsx
@@ -4,6 +4,7 @@ import {
   CUSTOMER_SERVICE_EMAIL,
   HEADER_BOTTOM_LINKS,
 } from '~/constants/constant'
+import { withBasePath } from '~/constants/with-base-path'
 import styles from './_styles/footer.module.scss'
 
 const footerRightList = [
@@ -58,7 +59,7 @@ export default function Footer(): JSX.Element {
             <div className={styles.logo}>
               <Link href="/">
                 <Image
-                  src="/icons/mnews-logo-white.svg"
+                  src={withBasePath('/icons/mnews-logo-white.svg')}
                   alt="mnews logo"
                   priority
                   width={163}
@@ -77,7 +78,7 @@ export default function Footer(): JSX.Element {
                     rel="noopener noreferrer"
                   >
                     <Image
-                      src={link.src}
+                      src={withBasePath(link.src)}
                       alt={link.alt}
                       width={20}
                       height={20}
@@ -127,7 +128,12 @@ export default function Footer(): JSX.Element {
           {socialLinks.map((link, index) => (
             <li className={styles.icon} key={index}>
               <Link href={link.href} target="_blank" rel="noopener noreferrer">
-                <Image src={link.src} alt={link.alt} width={20} height={20} />
+                <Image
+                  src={withBasePath(link.src)}
+                  alt={link.alt}
+                  width={20}
+                  height={20}
+                />
               </Link>
             </li>
           ))}

--- a/packages/mirror-tv-next/components/layout/header/desktop-search-bar.tsx
+++ b/packages/mirror-tv-next/components/layout/header/desktop-search-bar.tsx
@@ -2,6 +2,7 @@
 import styles from './_styles/header-search-bar.module.scss'
 import Image from 'next/image'
 import { FormEvent, useState } from 'react'
+import { withBasePath } from '~/constants/with-base-path'
 
 const HeaderSearchBar = () => {
   const [keyword, setKeyword] = useState('')
@@ -23,7 +24,7 @@ const HeaderSearchBar = () => {
       <button type="submit" className={`${styles.searchButton} search-icon`}>
         <Image
           className={styles.searchInputIcon}
-          src="/icons/icon-search.svg"
+          src={withBasePath('/icons/icon-search.svg')}
           alt="search icon"
           fill
         />

--- a/packages/mirror-tv-next/components/layout/header/header-top.tsx
+++ b/packages/mirror-tv-next/components/layout/header/header-top.tsx
@@ -5,6 +5,7 @@ import type { Sponsor } from '~/graphql/query/sponsors'
 import { formateHeroImage } from '~/utils'
 import ResponsiveImage from '~/components/shared/responsive-image'
 import { TV_AD_ADMIN_OEN_URL } from '~/constants/constant'
+import { withBasePath } from '~/constants/with-base-path'
 
 type HeaderTopProps = {
   sponsors: Sponsor[]
@@ -17,7 +18,7 @@ export default function HeaderTop({ sponsors }: HeaderTopProps) {
         <div className={[styles.logo, 'top-wrapper__left'].join(' ')}>
           <Link href="/" className="logo">
             <Image
-              src="/icons/mnews-logo.svg"
+              src={withBasePath('/icons/mnews-logo.svg')}
               alt="mnews logo"
               priority
               width={192}
@@ -34,7 +35,7 @@ export default function HeaderTop({ sponsors }: HeaderTopProps) {
             rel="noreferrer noopener"
           >
             <Image
-              src="/images/tv-ad-admin-banner.gif"
+              src={withBasePath('/images/tv-ad-admin-banner.gif')}
               alt="Mnews TV Ad Admin Banner"
               width={1266}
               height={712}

--- a/packages/mirror-tv-next/components/layout/header/mobile-header/_styles/search-bar.module.scss
+++ b/packages/mirror-tv-next/components/layout/header/mobile-header/_styles/search-bar.module.scss
@@ -62,8 +62,8 @@
   width: 28px;
   height: 26px;
   background-color: #ffffff;
-  mask: url('/icons/icon-search.svg') 0 0/28px 26px;
-  -webkit-mask: url('/icons/icon-search.svg') 0 0/28px 26px;
+  mask: var(--search-icon-url) 0 0/28px 26px;
+  -webkit-mask: var(--search-icon-url) 0 0/28px 26px;
 }
 
 .searchIconWrapper {

--- a/packages/mirror-tv-next/components/layout/header/mobile-header/mobile-nav.tsx
+++ b/packages/mirror-tv-next/components/layout/header/mobile-header/mobile-nav.tsx
@@ -2,6 +2,7 @@ import Image from 'next/image'
 import Link from 'next/link'
 import type { Category } from '~/graphql/query/category'
 import type { Sponsor } from '~/graphql/query/sponsors'
+import { withBasePath } from '~/constants/with-base-path'
 import styles from './_styles/mobile-nav.module.scss'
 import SideMenu from './side-menu'
 import MobileSearchBar from './mobile-search-bar'
@@ -17,7 +18,7 @@ export default function MobileNav({ categories, sponsors }: MobileNavProps) {
       <div className={styles.logo}>
         <Link href="/">
           <Image
-            src="/icons/mnews-logo-white.svg"
+            src={withBasePath('/icons/mnews-logo-white.svg')}
             alt="mnews logo"
             width={162}
             height={30}

--- a/packages/mirror-tv-next/components/layout/header/mobile-header/mobile-search-bar.tsx
+++ b/packages/mirror-tv-next/components/layout/header/mobile-header/mobile-search-bar.tsx
@@ -2,6 +2,7 @@
 import { useState } from 'react'
 import styles from './_styles/search-bar.module.scss'
 import Image from 'next/image'
+import { withBasePath } from '~/constants/with-base-path'
 
 const MobileSearchBar = () => {
   const [isSearchBarShown, setIsSearchBarShown] = useState(false)
@@ -49,7 +50,7 @@ const MobileSearchBar = () => {
               <button onClick={handleResetKeyword}>
                 <Image
                   className={styles.resetIcon}
-                  src="/icons/icon-cross.svg"
+                  src={withBasePath('/icons/icon-cross.svg')}
                   alt="search icon"
                   width={16}
                   height={16}

--- a/packages/mirror-tv-next/components/layout/header/mobile-header/mobile-search-bar.tsx
+++ b/packages/mirror-tv-next/components/layout/header/mobile-header/mobile-search-bar.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useState } from 'react'
+import { type CSSProperties, useState } from 'react'
 import styles from './_styles/search-bar.module.scss'
 import Image from 'next/image'
 import { withBasePath } from '~/constants/with-base-path'
@@ -28,11 +28,14 @@ const MobileSearchBar = () => {
   const searchIconClassName = isSearchBarShown
     ? `${styles.logo} ${styles.isActive}`
     : styles.logo
+  const searchIconStyle = {
+    '--search-icon-url': `url(${withBasePath('/icons/icon-search.svg')})`,
+  } as CSSProperties
 
   return (
     <div className={styles.searchBarContainer}>
       <button onClick={toggleSearchBar}>
-        <div className={searchIconClassName} />
+        <div className={searchIconClassName} style={searchIconStyle} />
       </button>
       {isSearchBarShown && (
         <section className={styles.searchBarSection}>

--- a/packages/mirror-tv-next/components/layout/header/mobile-header/side-menu.tsx
+++ b/packages/mirror-tv-next/components/layout/header/mobile-header/side-menu.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useEffect, useState } from 'react'
 import { HEADER_BOTTOM_LINKS } from '~/constants/constant'
+import { withBasePath } from '~/constants/with-base-path'
 import type { Category } from '~/graphql/query/category'
 import type { Show } from '~/types/header'
 import type { Sponsor } from '~/graphql/query/sponsors'
@@ -87,7 +88,7 @@ export default function SideMenu({ categories, sponsors }: SideMenuProps) {
         className={toggleButtonClasses}
       >
         <Image
-          src="/icons/side-menu-icon.svg"
+          src={withBasePath('/icons/side-menu-icon.svg')}
           alt="menu icon"
           width={28}
           height={26}
@@ -117,8 +118,8 @@ export default function SideMenu({ categories, sponsors }: SideMenuProps) {
                         alt="Sponsor Logo"
                         images={images}
                         imagesWebP={imagesWebP}
-                        loadingImage="/images/loading.svg"
-                        defaultImage="/images/image-default.jpg"
+                        loadingImage={withBasePath('/images/loading.svg')}
+                        defaultImage={withBasePath('/images/image-default.jpg')}
                         rwd={{ default: '100px' }}
                         priority={true}
                       />
@@ -205,7 +206,12 @@ export default function SideMenu({ categories, sponsors }: SideMenuProps) {
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  <Image src={link.src} alt={link.alt} width={20} height={20} />
+                  <Image
+                    src={withBasePath(link.src)}
+                    alt={link.alt}
+                    width={20}
+                    height={20}
+                  />
                 </Link>
               </li>
             ))}

--- a/packages/mirror-tv-next/components/layout/header/other-items.tsx
+++ b/packages/mirror-tv-next/components/layout/header/other-items.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image'
 import Link from 'next/link'
 import { HEADER_BOTTOM_LINKS } from '~/constants/constant'
+import { withBasePath } from '~/constants/with-base-path'
 import styles from './_styles/other-items.module.scss'
 
 export default function OtherItems(): JSX.Element {
@@ -43,7 +44,7 @@ export default function OtherItems(): JSX.Element {
             >
               {item.iconSrc ? (
                 <Image
-                  src={item.iconSrc}
+                  src={withBasePath(item.iconSrc)}
                   alt={item.alt || ''}
                   width={20}
                   height={20}

--- a/packages/mirror-tv-next/components/shared/ad-tv-admin-mobile-banner.tsx
+++ b/packages/mirror-tv-next/components/shared/ad-tv-admin-mobile-banner.tsx
@@ -3,6 +3,7 @@
 import Image from 'next/image'
 import Link from 'next/link'
 import { TV_AD_ADMIN_OEN_URL } from '~/constants/constant'
+import { withBasePath } from '~/constants/with-base-path'
 
 import styles from './_styles/ad-tv-admin-mobile-banner.module.scss'
 
@@ -21,7 +22,7 @@ export default function AdTvAdminMobileBanner({
         rel="noreferrer noopener"
       >
         <Image
-          src="/images/tv-ad-admin-banner.gif"
+          src={withBasePath('/images/tv-ad-admin-banner.gif')}
           alt="Mnews TV Ad Admin Banner"
           width={1266}
           height={712}

--- a/packages/mirror-tv-next/components/shared/responsive-image.tsx
+++ b/packages/mirror-tv-next/components/shared/responsive-image.tsx
@@ -1,5 +1,6 @@
 'use client'
 import Image from '@readr-media/react-image'
+import { withBasePath } from '~/constants/with-base-path'
 import { getSotThumbnailObjectFit, type PostImage } from '~/utils'
 
 type UiPostCardProps = {
@@ -38,8 +39,8 @@ export default function ResponsiveImage({
       images={images}
       imagesWebP={imagesWebP}
       alt={alt}
-      loadingImage={priority ? undefined : '/images/loading.svg'}
-      defaultImage="/images/image-default.jpg"
+      loadingImage={priority ? undefined : withBasePath('/images/loading.svg')}
+      defaultImage={withBasePath('/images/image-default.jpg')}
       rwd={rwd}
       priority={priority}
       className={imgClassName}

--- a/packages/mirror-tv-next/components/shared/ui-download.tsx
+++ b/packages/mirror-tv-next/components/shared/ui-download.tsx
@@ -1,4 +1,5 @@
 import styles from './_styles/ui-download.module.scss'
+import { withBasePath } from '~/constants/with-base-path'
 
 export type DownloadItem = {
   id: string
@@ -28,7 +29,7 @@ export default function UiDownload({ downloads }: UiDownloadProps) {
           >
             <span className={styles.title}>{download.name}</span>
             <img
-              src="/icons/download.svg"
+              src={withBasePath('/icons/download.svg')}
               alt="download"
               className={styles.btn}
             />

--- a/packages/mirror-tv-next/components/story/api-data-renderer/block-renderer/blockquote-block.tsx
+++ b/packages/mirror-tv-next/components/story/api-data-renderer/block-renderer/blockquote-block.tsx
@@ -2,6 +2,7 @@ import Image from 'next/image'
 import styles from './_styles/blockquote-block.module.scss'
 import { type ApiDataBlockBase, ApiDataBlockType } from './type'
 import { getFirstElement } from '~/utils/common'
+import { withBasePath } from '~/constants/with-base-path'
 
 export interface ApiDataBlockquote extends ApiDataBlockBase {
   type: ApiDataBlockType.Blockquote
@@ -20,7 +21,11 @@ const BlockquoteBlock = ({ data }: { data: ApiDataBlockquote }) => {
     <div className={styles.blockquoteBlock}>
       <div className={mergeClasses(styles.imageContainer, styles.start)}>
         <div className={styles.imageWrapper}>
-          <Image src="/icons/icon-quote-start.svg" alt="quote start" fill />
+          <Image
+            src={withBasePath('/icons/icon-quote-start.svg')}
+            alt="quote start"
+            fill
+          />
         </div>
       </div>
       <blockquote>
@@ -28,7 +33,11 @@ const BlockquoteBlock = ({ data }: { data: ApiDataBlockquote }) => {
       </blockquote>
       <div className={mergeClasses(styles.imageContainer, styles.end)}>
         <div className={styles.imageWrapper}>
-          <Image src="/icons/icon-quote-end.svg" alt="quote end" fill />
+          <Image
+            src={withBasePath('/icons/icon-quote-end.svg')}
+            alt="quote end"
+            fill
+          />
         </div>
       </div>
     </div>

--- a/packages/mirror-tv-next/components/story/article-hero-image-and-video.tsx
+++ b/packages/mirror-tv-next/components/story/article-hero-image-and-video.tsx
@@ -4,6 +4,7 @@ import styles from './_styles/article-hero-image-and-video.module.scss'
 import Image from '@readr-media/react-image'
 import { formateHeroImage } from '~/utils/image-handler'
 import { extractYoutubeId } from '~/utils'
+import { withBasePath } from '~/constants/with-base-path'
 
 type ArticleHeroImageAndVideoProps = {
   heroImage: SinglePost['heroImage']
@@ -38,7 +39,7 @@ const ArticleHeroImageAndVideo: React.FC<ArticleHeroImageAndVideoProps> = (
             images={images}
             imagesWebP={imagesWebP}
             alt={title}
-            defaultImage="/images/image-default.jpg"
+            defaultImage={withBasePath('/images/image-default.jpg')}
             rwd={{
               mobile: '100vw',
               tablet: '100vw',

--- a/packages/mirror-tv-next/components/story/article-social-list.tsx
+++ b/packages/mirror-tv-next/components/story/article-social-list.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image'
 import styles from './_styles/article-social-list.module.scss'
 import { socialMediaConfig, socialMediaOrder } from '~/constants/social-medial'
+import { withBasePath } from '~/constants/with-base-path'
 
 const ArticleSocialList = () => {
   return (
@@ -18,7 +19,7 @@ const ArticleSocialList = () => {
           const { image, href } = socialMediaData
           const imageConfig = {
             alt: socialMedia,
-            src: image || defaultImageSrc,
+            src: withBasePath(image || defaultImageSrc),
             width: imageSize,
             height: imageSize,
           } satisfies Parameters<typeof Image>[0]

--- a/packages/mirror-tv-next/components/story/share-button.tsx
+++ b/packages/mirror-tv-next/components/story/share-button.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import styles from './_styles/share-button.module.scss'
+import { withBasePath } from '~/constants/with-base-path'
 
 type ShareType = 'facebook' | 'line' | 'twitter' | 'copy'
 
@@ -107,7 +108,11 @@ const ShareButton = ({ type, url, className }: ShareButtonProps) => {
           rel="noopener noreferrer"
         >
           <span>
-            <img src={config.icon} alt={config.alt} loading="lazy" />
+            <img
+              src={withBasePath(config.icon)}
+              alt={config.alt}
+              loading="lazy"
+            />
           </span>
         </a>
       </div>
@@ -123,7 +128,7 @@ const ShareButton = ({ type, url, className }: ShareButtonProps) => {
       onClick={handleCopyClick}
     >
       <span>
-        <img src={config.icon} alt={config.alt} loading="lazy" />
+        <img src={withBasePath(config.icon)} alt={config.alt} loading="lazy" />
       </span>
     </button>
   )

--- a/packages/mirror-tv-next/constants/site-base-path.cjs
+++ b/packages/mirror-tv-next/constants/site-base-path.cjs
@@ -1,0 +1,8 @@
+// Keep this file in CommonJS so next.config.js can load the preview basePath
+// directly in Node before Next.js compiles the TypeScript application code.
+const SITE_BASE_PATH =
+  process.env.NEXT_PUBLIC_IS_PREVIEW_MODE === 'true' ? '/preview-server' : ''
+
+module.exports = {
+  SITE_BASE_PATH,
+}

--- a/packages/mirror-tv-next/constants/with-base-path.ts
+++ b/packages/mirror-tv-next/constants/with-base-path.ts
@@ -35,7 +35,11 @@ import { SITE_BASE_PATH } from './site-base-path.cjs'
  */
 function withBasePath(path: string): string {
   if (!path.startsWith('/') || path.startsWith('//')) return path
-  if (SITE_BASE_PATH && path.startsWith(`${SITE_BASE_PATH}/`)) return path
+  if (
+    SITE_BASE_PATH &&
+    (path === SITE_BASE_PATH || path.startsWith(`${SITE_BASE_PATH}/`))
+  )
+    return path
   return `${SITE_BASE_PATH}${path}`
 }
 

--- a/packages/mirror-tv-next/constants/with-base-path.ts
+++ b/packages/mirror-tv-next/constants/with-base-path.ts
@@ -1,0 +1,42 @@
+import { SITE_BASE_PATH } from './site-base-path.cjs'
+
+/**
+ * Prepend preview-server basePath to root-relative public asset paths.
+ *
+ * In production basePath = '', so this is effectively a no-op.
+ *
+ * Scope (intentional, not a partial rollout):
+ *   Preview mode only renders the `story/[slug]` and `external/[slug]` pages,
+ *   so this helper is applied only to public asset paths that those two pages
+ *   (and the shared layout/components they pull in) actually reach — e.g.
+ *   visible header logo/banner, `ResponsiveImage` fallbacks, share icons,
+ *   blockquote icons, and attachment download icons. Pages outside the preview
+ *   surface (category, topic, show, errors, etc.) are intentionally NOT wrapped.
+ *
+ *   If preview mode is later extended to cover more pages, expand the helper's
+ *   usage to those pages' callsites at that time — do not pre-wrap everything.
+ *
+ * Use for visible `/images/...`, `/icons/...`, or `/fonts/...` paths that are
+ * reached by `story/[slug]` or `external/[slug]` in preview mode.
+ *
+ * Do NOT use for:
+ *   - Callsites only reached by non-preview pages — out of scope
+ *   - SEO metadata, JSON-LD, Open Graph, or Twitter card image paths — those
+ *     are not part of the visible preview image fix and may need absolute URLs
+ *   - External absolute URLs (`https://...`) — basePath does not apply
+ *   - Bundler-handled imports (`import Foo from '~/public/icons/foo.svg'`)
+ *     — webpack/svgr resolves the final URL at build time
+ *   - `<Link href>` / `useRouter().push()` — Next.js auto-applies basePath
+ *
+ * Why this exists: Next.js basePath is build-time and is NOT auto-applied to
+ * `<Image src>`, third-party image components (e.g. @readr-media/react-image),
+ * native `<img src>`, or CSS `url()` paths. Bug surface is preview-only —
+ * production has basePath = '' so missing helper calls are invisible there.
+ */
+function withBasePath(path: string): string {
+  if (!path.startsWith('/') || path.startsWith('//')) return path
+  if (SITE_BASE_PATH && path.startsWith(`${SITE_BASE_PATH}/`)) return path
+  return `${SITE_BASE_PATH}${path}`
+}
+
+export { SITE_BASE_PATH, withBasePath }

--- a/packages/mirror-tv-next/constants/with-base-path.ts
+++ b/packages/mirror-tv-next/constants/with-base-path.ts
@@ -12,6 +12,8 @@ import { SITE_BASE_PATH } from './site-base-path.cjs'
  *   visible header logo/banner, `ResponsiveImage` fallbacks, share icons,
  *   blockquote icons, and attachment download icons. Pages outside the preview
  *   surface (category, topic, show, errors, etc.) are intentionally NOT wrapped.
+ *   SEO metadata, JSON-LD, Open Graph, and Twitter card image paths are also
+ *   out of scope for this round and are not wrapped here.
  *
  *   If preview mode is later extended to cover more pages, expand the helper's
  *   usage to those pages' callsites at that time — do not pre-wrap everything.
@@ -21,8 +23,6 @@ import { SITE_BASE_PATH } from './site-base-path.cjs'
  *
  * Do NOT use for:
  *   - Callsites only reached by non-preview pages — out of scope
- *   - SEO metadata, JSON-LD, Open Graph, or Twitter card image paths — those
- *     are not part of the visible preview image fix and may need absolute URLs
  *   - External absolute URLs (`https://...`) — basePath does not apply
  *   - Bundler-handled imports (`import Foo from '~/public/icons/foo.svg'`)
  *     — webpack/svgr resolves the final URL at build time

--- a/packages/mirror-tv-next/next.config.js
+++ b/packages/mirror-tv-next/next.config.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const path = require('path')
-const SITE_BASE_PATH =
-  process.env.NEXT_PUBLIC_IS_PREVIEW_MODE === 'true' ? '/preview-server' : ''
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { SITE_BASE_PATH } = require('./constants/site-base-path.cjs')
 
 const mnewsImageHostnames = [
   'v3.mnews.tw',

--- a/packages/mirror-tv-next/utils/image-handler.ts
+++ b/packages/mirror-tv-next/utils/image-handler.ts
@@ -3,6 +3,7 @@ import type {
   FormattableHeroImage,
   K6NestedHeroImage,
 } from '~/types/hero-image'
+import { withBasePath } from '~/constants/with-base-path'
 
 export type PostImage = {
   original: string
@@ -47,7 +48,7 @@ function toNonEmptyString(value?: string | null) {
 
 function createDefaultPostImage(): PostImage {
   return {
-    original: '/images/image-default.jpg',
+    original: withBasePath('/images/image-default.jpg'),
   }
 }
 


### PR DESCRIPTION
PR #541 enabled Next.js `basePath: '/preview-server'` for preview mode,
but Next.js does NOT auto-apply `basePath` to root-relative public asset
paths used by `<Image src>`, third-party image components, native `<img>`,
or CSS `url()`. As a result, preview-mode `story/[slug]` and `external/[slug]`
pages currently 404 on visible images such as the header logo, banner,
`ResponsiveImage` fallbacks, share icons, and the blockquote / download icons.

## What this PR does
- Adds `constants/site-base-path.cjs` as a single source of truth for
  `SITE_BASE_PATH`, shared between `next.config.js` (CommonJS) and TS code.
- Adds a `withBasePath()` helper in `constants/with-base-path.ts`. In
  production (`basePath = ''`) it is a no-op.
- Wraps public asset paths in callsites that `story/[slug]` and
  `external/[slug]` actually reach (header / footer / shared components /
  story-level icons and fallbacks), plus one CSS-variable example in
  `mobile-search-bar.tsx` + `search-bar.module.scss`.

## Scope (intentional, not a partial rollout)
- Preview mode currently only renders `story/[slug]` and `external/[slug]`,
  so only their reachable callsites are wrapped.
- Non-preview pages (category, topic, show, errors, etc.) are NOT wrapped.
- SEO metadata / JSON-LD / Open Graph / Twitter card image fallbacks are
  NOT touched — they may need absolute URLs and are out of scope here.
- Global CSS (`styles/miso-search.css`), manifest, favicon, and fonts are
  out of scope; see follow-up notes in the execution plan.
## Additions
- `packages/mirror-tv-next/constants/site-base-path.cjs`: A CommonJS constant file to share the `SITE_BASE_PATH` between Node.js (`next.config.js`) and TypeScript code.
- `packages/mirror-tv-next/constants/with-base-path.ts`: A helper function that prepends `SITE_BASE_PATH` to root-relative paths.

## Changes
- `packages/mirror-tv-next/next.config.js`: Refactored to import `SITE_BASE_PATH` from the new `.cjs` constant file.
- `packages/mirror-tv-next/components/layout/`: Applied `withBasePath` to logos and icons in `Footer`, `Header`, and `SideMenu`.
- `packages/mirror-tv-next/components/shared/`: Updated `ResponsiveImage`, `AdTvAdminMobileBanner`, and `UiDownload` to use the helper for their respective asset paths.
- `packages/mirror-tv-next/components/story/`: Updated `ArticleSocialList`, `ShareButton`, and `BlockquoteBlock` to support the preview pathing.
- `packages/mirror-tv-next/utils/image-handler.ts`: Updated default image fallback paths to use `withBasePath`.
- `packages/mirror-tv-next/components/layout/header/mobile-header/`: Implemented a CSS variable injection strategy in `MobileSearchBar` to pass the correct icon URL to the SCSS `mask` property.

## Testing
- Verified that `withBasePath` returns the original path when `NEXT_PUBLIC_IS_PREVIEW_MODE` is not set (production no-op).
- Verified that asset paths are correctly prefixed with `/preview-server` when preview mode is active.
- Checked story and external pages in preview mode to ensure no 404s for icons and placeholder images.

## Task Links
[前端-電視Preview頁image路徑修改 - Asana](https://app.asana.com/1/614399484723017/project/1210724947067404/task/1214726260523603?focus=true)