### PR TITLE
fix: enhance category handling in external post data

### DIFF
--- a/packages/mirror-tv-next/app/external/[slug]/page.tsx
+++ b/packages/mirror-tv-next/app/external/[slug]/page.tsx
@@ -96,7 +96,8 @@ function generateExternalJsonLds(
   externalData: SingleExternalPost,
   pageUrl: string
 ) {
-  const category = externalData.categories?.[0]
+  const category =
+    externalData.categoriesInInputOrder?.[0] || externalData.categories?.[0]
   const logoUrl = '/images/logo.png' // 需要確認實際的 logo 路徑
 
   // 將時間轉換為台北時區
@@ -169,7 +170,8 @@ function generateBreadcrumbList(
   externalData: SingleExternalPost,
   pageUrl: string
 ) {
-  const category = externalData.categories?.[0]
+  const category =
+    externalData.categoriesInInputOrder?.[0] || externalData.categories?.[0]
   const items = [
     {
       '@type': 'ListItem',
@@ -223,7 +225,8 @@ export async function generateMetadata({
   const pageUrl = `${META_SITE_URL}/external/${params.slug}`
   const writer = externalData.byline
   const authorName = writer || SITE_TITLE
-  const category = externalData.categories?.[0]
+  const category =
+    externalData.categoriesInInputOrder?.[0] || externalData.categories?.[0]
   const publishTime = externalData.publishTime
   const updateTime = externalData.updatedAt || externalData.publishTime
 
@@ -286,6 +289,7 @@ const ExternalPage = async (props: ExternalPageTypes) => {
     content_original,
     heroCaption,
     categories,
+    categoriesInInputOrder,
     name: title,
     publishTime,
     thumbnail,
@@ -320,6 +324,7 @@ const ExternalPage = async (props: ExternalPageTypes) => {
   const pageUrl = `${META_SITE_URL}/external/${params.slug}`
   const jsonLdData = generateExternalJsonLds(externalData, pageUrl)
   const briefText = extractBriefText(externalData)
+  const category = categoriesInInputOrder?.[0] || categories?.[0]
 
   const extra = {
     externalId: id,
@@ -353,9 +358,9 @@ const ExternalPage = async (props: ExternalPageTypes) => {
           title={title}
           publishTime={publishTimeTaipei}
           category={
-            categories?.[0]
-              ? { slug: categories[0].slug, title: categories[0].name }
-              : { slug: '', title: '' }
+            category
+              ? { title: category.name, slug: category.slug }
+              : { title: '', slug: '' }
           }
           writers={
             partner?.name ? [{ name: partner?.name || '', slug: '' }] : []

--- a/packages/mirror-tv-next/app/external/[slug]/page.tsx
+++ b/packages/mirror-tv-next/app/external/[slug]/page.tsx
@@ -92,12 +92,17 @@ function extractBriefText(externalData: SingleExternalPost): string {
   return brief
 }
 
+function getPrimaryCategory(externalData: SingleExternalPost) {
+  return (
+    externalData.categoriesInInputOrder?.[0] || externalData.categories?.[0]
+  )
+}
+
 function generateExternalJsonLds(
   externalData: SingleExternalPost,
   pageUrl: string
 ) {
-  const category =
-    externalData.categoriesInInputOrder?.[0] || externalData.categories?.[0]
+  const category = getPrimaryCategory(externalData)
   const logoUrl = '/images/logo.png' // 需要確認實際的 logo 路徑
 
   // 將時間轉換為台北時區
@@ -109,7 +114,7 @@ function generateExternalJsonLds(
   const jsonLdBreadcrumbList = {
     '@context': 'http://schema.org/',
     '@type': 'BreadcrumbList',
-    itemListElement: generateBreadcrumbList(externalData, pageUrl),
+    itemListElement: generateBreadcrumbList(externalData, pageUrl, category),
   }
   const brief = extractBriefText(externalData)
 
@@ -168,10 +173,9 @@ function generateExternalJsonLds(
 
 function generateBreadcrumbList(
   externalData: SingleExternalPost,
-  pageUrl: string
+  pageUrl: string,
+  category = getPrimaryCategory(externalData)
 ) {
-  const category =
-    externalData.categoriesInInputOrder?.[0] || externalData.categories?.[0]
   const items = [
     {
       '@type': 'ListItem',
@@ -225,8 +229,7 @@ export async function generateMetadata({
   const pageUrl = `${META_SITE_URL}/external/${params.slug}`
   const writer = externalData.byline
   const authorName = writer || SITE_TITLE
-  const category =
-    externalData.categoriesInInputOrder?.[0] || externalData.categories?.[0]
+  const category = getPrimaryCategory(externalData)
   const publishTime = externalData.publishTime
   const updateTime = externalData.updatedAt || externalData.publishTime
 
@@ -289,7 +292,6 @@ const ExternalPage = async (props: ExternalPageTypes) => {
     content_original,
     heroCaption,
     categories,
-    categoriesInInputOrder,
     name: title,
     publishTime,
     thumbnail,
@@ -324,7 +326,7 @@ const ExternalPage = async (props: ExternalPageTypes) => {
   const pageUrl = `${META_SITE_URL}/external/${params.slug}`
   const jsonLdData = generateExternalJsonLds(externalData, pageUrl)
   const briefText = extractBriefText(externalData)
-  const category = categoriesInInputOrder?.[0] || categories?.[0]
+  const category = getPrimaryCategory(externalData)
 
   const extra = {
     externalId: id,

--- a/packages/mirror-tv-next/graphql/query/external.ts
+++ b/packages/mirror-tv-next/graphql/query/external.ts
@@ -31,8 +31,8 @@ export interface SingleExternalPost {
   }[]
   categoriesInInputOrder?: {
     id: string
-    name: string
     slug: string
+    name: string
   }[]
   // subtitle?: string
   publishTime: string

--- a/packages/mirror-tv-next/graphql/query/external.ts
+++ b/packages/mirror-tv-next/graphql/query/external.ts
@@ -29,6 +29,11 @@ export interface SingleExternalPost {
     slug: string
     name: string
   }[]
+  categoriesInInputOrder?: {
+    id: string
+    name: string
+    slug: string
+  }[]
   // subtitle?: string
   publishTime: string
   byline?: string | null
@@ -62,6 +67,11 @@ const fetchExternalBySlug = gql`
         slug
       }
       categories {
+        id
+        slug
+        name
+      }
+      categoriesInInputOrder {
         id
         slug
         name


### PR DESCRIPTION
Change:

1. Replace ‎`category` with ‎`categoriesInInputOrder`

Why:

Originally planned to use ‎`manualOrderOfCategories`, but switched to ‎`categoriesInInputOrder` to preserve both ordering and the ‎`slug` field.

REF:

[前端-External頁分類改抓manualOrderOfCategories欄位](https://app.asana.com/1/614399484723017/project/1214559748867622/task/1214559748867618?focus=true)