### PR TITLE
feat: add keywords to JSON-LD for improved SEO metadata

### DIFF
--- a/packages/mirror-tv-next/app/story/[slug]/page.tsx
+++ b/packages/mirror-tv-next/app/story/[slug]/page.tsx
@@ -83,9 +83,8 @@ function generateStoryJsonLds(storyData: SinglePost, pageUrl: string) {
     .map((item: { content?: string[] }) => item.content?.join('') || '')
     .join('')
 
-  const keywordsArray =
-    storyData.tagsInInputOrder?.map((tag: { name: string }) => tag.name) ||
-    storyData.tags?.map((tag: { name: string }) => tag.name)
+  const tagsRendered = storyData.tagsInInputOrder || storyData.tags
+  const keywords = tagsRendered?.map((tag) => tag.name).join(', ') || ''
 
   const jsonLdBreadcrumbList = {
     '@context': 'http://schema.org/',
@@ -120,7 +119,7 @@ function generateStoryJsonLds(storyData: SinglePost, pageUrl: string) {
     url: pageUrl,
     thumbnailUrl: getStoryOgImage(storyData.heroImage),
     articleSection: categoryName,
-    keywords: keywordsArray,
+    keywords,
   }
 
   let jsonLdPerson

--- a/packages/mirror-tv-next/app/story/[slug]/page.tsx
+++ b/packages/mirror-tv-next/app/story/[slug]/page.tsx
@@ -83,6 +83,10 @@ function generateStoryJsonLds(storyData: SinglePost, pageUrl: string) {
     .map((item: { content?: string[] }) => item.content?.join('') || '')
     .join('')
 
+  const keywordsArray =
+    storyData.tagsInInputOrder?.map((tag: { name: string }) => tag.name) ||
+    storyData.tags?.map((tag: { name: string }) => tag.name)
+
   const jsonLdBreadcrumbList = {
     '@context': 'http://schema.org/',
     '@type': 'BreadcrumbList',
@@ -116,6 +120,7 @@ function generateStoryJsonLds(storyData: SinglePost, pageUrl: string) {
     url: pageUrl,
     thumbnailUrl: getStoryOgImage(storyData.heroImage),
     articleSection: categoryName,
+    keywords: keywordsArray,
   }
 
   let jsonLdPerson
@@ -311,7 +316,6 @@ const StoryPage = async (props: StoryPageTypes) => {
 
   const pageUrl = `${META_SITE_URL}/story/${params.slug}`
   const jsonLdData = generateStoryJsonLds(storyData, pageUrl)
-
   // 為了通過 BigQuery 的型別規則，故用 toString() 將陣列轉成字串，來統一以下部分屬性有值和無值時的型別，非 view log 相關用途請勿更動
   const extra = {
     storyId: id,


### PR DESCRIPTION
Add
1. add keywords which generate from storyData  tagsInInputOrder  to JSON-LD for improved SEO metadata



REF
[News article JSON-LD加上keywords](https://app.asana.com/1/614399484723017/project/1215184739359712/task/1213533264787392?focus=true)