### PR TITLE
fix: update class names and add styles for popin components

### DIFF
--- a/packages/mirror-tv-next/components/story/_styles/ad-after-story.module.scss
+++ b/packages/mirror-tv-next/components/story/_styles/ad-after-story.module.scss
@@ -12,3 +12,6 @@
     color: #153047 !important;
   }
 }
+.popinRecommend {
+  min-height: 344px;
+}

--- a/packages/mirror-tv-next/components/story/_styles/article-related-posts.module.scss
+++ b/packages/mirror-tv-next/components/story/_styles/article-related-posts.module.scss
@@ -48,4 +48,11 @@
       }
     }
   }
+  .popinAd {
+    min-height: 230px;
+
+    @media (min-width: 768px) {
+      min-height: 160px;
+    }
+  }
 }

--- a/packages/mirror-tv-next/components/story/ad-after-story.tsx
+++ b/packages/mirror-tv-next/components/story/ad-after-story.tsx
@@ -68,7 +68,7 @@ const AdAfterStory: React.FC = () => {
               title="每日精選"
               className={styles.dailySelection}
             />
-            <div id="_popIn_recommend" className="popin_recommend" />
+            <div id="_popIn_recommend" className={styles.popinRecommend} />
           </>
         )}
       </LazyRenderWrapper>

--- a/packages/mirror-tv-next/components/story/ad-after-story.tsx
+++ b/packages/mirror-tv-next/components/story/ad-after-story.tsx
@@ -68,7 +68,10 @@ const AdAfterStory: React.FC = () => {
               title="每日精選"
               className={styles.dailySelection}
             />
-            <div id="_popIn_recommend" className={styles.popinRecommend} />
+            <div
+              id="_popIn_recommend"
+              className={`popin_recommend ${styles.popinRecommend}`}
+            />
           </>
         )}
       </LazyRenderWrapper>


### PR DESCRIPTION
Add

1. Changed class name for the popin recommendation div to use the new styles.
2. Added min-height styles for the popinRecommend and popinAd classes in the respective SCSS files.


Ref

[Popin廣告版位設預設高度](https://app.asana.com/1/614399484723017/project/1215184739359712/task/1214371553619076?focus=true)