### PR TITLE
fix: restructure popin ad component for improved layout

### DIFF
--- a/packages/mirror-tv-next/components/story/article-related-posts.tsx
+++ b/packages/mirror-tv-next/components/story/article-related-posts.tsx
@@ -42,9 +42,11 @@ const ArticleRelatedPosts = ({
       </ul>
       {shouldShowAds && (
         <>
-          <LazyRenderWrapper>
-            <div id="_popIn_recommend_word" className={styles.popinAd} />
-          </LazyRenderWrapper>
+          <div className={styles.popinAd}>
+            <LazyRenderWrapper>
+              <div id="_popIn_recommend_word" />
+            </LazyRenderWrapper>
+          </div>
           {page === 'story' && (
             <LazyRenderWrapper>
               <div


### PR DESCRIPTION
Changed:

Moved the ‎`popinAd` style class from the inner ad element to an outer wrapper ‎`<div>`, so the placeholder height is applied to the container rather than the lazy-loaded content itself.

This ensures the reserved height for lazy loading remains visible before the ‎`<LazyRenderWrapper>` renders its children, preventing layout shift.

You can copy and paste this directly into the PR description field. The key point — that the placeholder height needs to exist outside the lazy-load boundary so the space is reserved before the content loads — is captured in the description.



[Popin廣告版位設預設高度](https://app.asana.com/1/614399484723017/project/1215184739359712/task/1214371553619076?focus=true)