### PR TITLE
Fix/dable ads

### DIFF
--- a/packages/mirror-tv-next/app/external/[slug]/layout.tsx
+++ b/packages/mirror-tv-next/app/external/[slug]/layout.tsx
@@ -19,25 +19,6 @@ export default function StoryPageLayout({
     <div className={styles.LayoutWrapper}>
       <TagManagerWrapper />
       <AdH1Remover />
-      <Script
-        id="dable"
-        strategy="afterInteractive"
-        dangerouslySetInnerHTML={{
-          __html: `
-            (function(d,a,b,l,e,_) {
-              d[b] = d[b] || function () {
-                (d[b].q = d[b].q || []).push(arguments)
-              }
-              e = a.createElement(l)
-              e.async = 1
-              e.charset = 'utf-8'
-              e.src = '//static.dable.io/dist/plugin.min.js'
-              _ = a.getElementsByTagName(l)[0]
-              _.parentNode.insertBefore(e, _)
-            })(window, document, 'dable', 'script')
-          `,
-        }}
-      />
 
       <Script
         id="popinAd"

--- a/packages/mirror-tv-next/app/story/[slug]/layout.tsx
+++ b/packages/mirror-tv-next/app/story/[slug]/layout.tsx
@@ -17,25 +17,6 @@ export default function StoryPageLayout({
   return (
     <div className={styles.LayoutWrapper}>
       <AdH1Remover />
-      <Script
-        id="dable"
-        strategy="afterInteractive"
-        dangerouslySetInnerHTML={{
-          __html: `
-            (function(d,a,b,l,e,_) {
-              d[b] = d[b] || function () {
-                (d[b].q = d[b].q || []).push(arguments)
-              }
-              e = a.createElement(l)
-              e.async = 1
-              e.charset = 'utf-8'
-              e.src = '//static.dable.io/dist/plugin.min.js'
-              _ = a.getElementsByTagName(l)[0]
-              _.parentNode.insertBefore(e, _)
-            })(window, document, 'dable', 'script')
-          `,
-        }}
-      />
 
       <Script
         id="popinAd"

--- a/packages/mirror-tv-next/components/story/_styles/ad-after-story.module.scss
+++ b/packages/mirror-tv-next/components/story/_styles/ad-after-story.module.scss
@@ -15,3 +15,12 @@
 .popinRecommend {
   min-height: 344px;
 }
+
+.dableWidgetLast {
+  min-height: 1050px;
+
+  @media (max-width: 767px) {
+    aspect-ratio: 343 / 1800;
+    min-height: 1800px;
+  }
+}

--- a/packages/mirror-tv-next/components/story/_styles/ad-dable-widget.module.scss
+++ b/packages/mirror-tv-next/components/story/_styles/ad-dable-widget.module.scss
@@ -1,0 +1,8 @@
+.dableWidgetLast {
+  min-height: 1050px;
+
+  @media (max-width: 767px) {
+    aspect-ratio: 343 / 1800;
+    min-height: 1800px;
+  }
+}

--- a/packages/mirror-tv-next/components/story/_styles/ad-popin-recommend.module.scss
+++ b/packages/mirror-tv-next/components/story/_styles/ad-popin-recommend.module.scss
@@ -1,4 +1,5 @@
 .dailySelection {
+  max-width: fit-content;
   border-image: linear-gradient(
       180deg,
       #153047 35%,
@@ -12,15 +13,7 @@
     color: #153047 !important;
   }
 }
+
 .popinRecommend {
   min-height: 344px;
-}
-
-.dableWidgetLast {
-  min-height: 1050px;
-
-  @media (max-width: 767px) {
-    aspect-ratio: 343 / 1800;
-    min-height: 1800px;
-  }
 }

--- a/packages/mirror-tv-next/components/story/ad-after-story.tsx
+++ b/packages/mirror-tv-next/components/story/ad-after-story.tsx
@@ -18,50 +18,47 @@ const AdAfterStory: React.FC = () => {
     <>
       <LazyRenderWrapper
         callbackFn={() => {
-          const initDable = () => {
-            const dableFunction = (window as unknown as { dable?: unknown })
-              .dable
-            const isDableReady =
-              typeof dableFunction === 'function' ||
-              (typeof dableFunction === 'object' &&
-                dableFunction &&
-                'q' in dableFunction)
-
-            if (isDableReady) {
-              try {
-                if (typeof dableFunction === 'function') {
-                  dableFunction('setService', 'mnews.tw')
-                  dableFunction(
-                    'renderWidgetByWidth',
-                    'dablewidget_2Xnxwk7d_xXAWmB7G'
-                  )
-                } else {
-                  ;(dableFunction as { q: unknown[] }).q.push([
-                    'setService',
-                    'mnews.tw',
-                  ])
-                  ;(dableFunction as { q: unknown[] }).q.push([
-                    'renderWidgetByWidth',
-                    'dablewidget_2Xnxwk7d_xXAWmB7G',
-                  ])
-                }
-              } catch (error) {
-                console.error('dable initialization failed:', error)
-              }
-            } else {
-              setTimeout(initDable, 1000)
-            }
+          type DableFunction = ((...args: unknown[]) => void) & {
+            q?: unknown[][]
+          }
+          const dableWindow = window as Window & {
+            dable?: DableFunction
           }
 
-          setTimeout(initDable, 2000)
+          if (!dableWindow.dable) {
+            const queuedDable = ((...args: unknown[]) => {
+              ;(queuedDable.q = queuedDable.q || []).push(args)
+            }) as DableFunction
+            dableWindow.dable = queuedDable
+          }
+
+          const dablePluginSrc = '//static.dable.io/dist/plugin.min.js'
+          const hasDablePlugin = !!document.querySelector(
+            `script[src="${dablePluginSrc}"]`
+          )
+          if (!hasDablePlugin) {
+            const scriptElement = document.createElement('script')
+            scriptElement.async = true
+            scriptElement.charset = 'utf-8'
+            scriptElement.src = dablePluginSrc
+            document.head.appendChild(scriptElement)
+          }
+
+          dableWindow.dable?.('setService', 'mnews.tw')
+          dableWindow.dable?.('sendLogOnce')
+          dableWindow.dable?.(
+            'renderWidgetByWidth',
+            'dablewidget_2Xnxwk7d_xXAWmB7G'
+          )
         }}
       >
         <div
           id="dablewidget_2Xnxwk7d_xXAWmB7G"
           data-widget_id-pc="2Xnxwk7d"
           data-widget_id-mo="xXAWmB7G"
-          className="dable-widget-last"
+          className={`dable-widget-last ${styles.dableWidgetLast}`}
         />
+
         {width && width >= 1200 && (
           <>
             <UiHeadingBordered

--- a/packages/mirror-tv-next/components/story/ad-after-story.tsx
+++ b/packages/mirror-tv-next/components/story/ad-after-story.tsx
@@ -1,78 +1,12 @@
-'use client'
-import useWindowDimensions from '~/hooks/use-window-dimensions'
-import styles from './_styles/ad-after-story.module.scss'
-
-import dynamic from 'next/dynamic'
-import UiHeadingBordered from '../shared/ui-heading-bordered'
-const LazyRenderWrapper = dynamic(
-  () => import('~/components/shared/lazy-render-wrapper'),
-  {
-    ssr: false,
-  }
-)
+import AdDableWidget from './ad-dable-widget'
+import AdPopinRecommend from './ad-popin-recommend'
 
 const AdAfterStory: React.FC = () => {
-  const { width } = useWindowDimensions()
-
   return (
-    <>
-      <LazyRenderWrapper
-        callbackFn={() => {
-          type DableFunction = ((...args: unknown[]) => void) & {
-            q?: unknown[][]
-          }
-          const dableWindow = window as Window & {
-            dable?: DableFunction
-          }
-
-          if (!dableWindow.dable) {
-            const queuedDable = ((...args: unknown[]) => {
-              ;(queuedDable.q = queuedDable.q || []).push(args)
-            }) as DableFunction
-            dableWindow.dable = queuedDable
-          }
-
-          const dablePluginSrc = '//static.dable.io/dist/plugin.min.js'
-          const hasDablePlugin = !!document.querySelector(
-            `script[src="${dablePluginSrc}"]`
-          )
-          if (!hasDablePlugin) {
-            const scriptElement = document.createElement('script')
-            scriptElement.async = true
-            scriptElement.charset = 'utf-8'
-            scriptElement.src = dablePluginSrc
-            document.head.appendChild(scriptElement)
-          }
-
-          dableWindow.dable?.('setService', 'mnews.tw')
-          dableWindow.dable?.('sendLogOnce')
-          dableWindow.dable?.(
-            'renderWidgetByWidth',
-            'dablewidget_2Xnxwk7d_xXAWmB7G'
-          )
-        }}
-      >
-        <div
-          id="dablewidget_2Xnxwk7d_xXAWmB7G"
-          data-widget_id-pc="2Xnxwk7d"
-          data-widget_id-mo="xXAWmB7G"
-          className={`dable-widget-last ${styles.dableWidgetLast}`}
-        />
-
-        {width && width >= 1200 && (
-          <>
-            <UiHeadingBordered
-              title="每日精選"
-              className={styles.dailySelection}
-            />
-            <div
-              id="_popIn_recommend"
-              className={`popin_recommend ${styles.popinRecommend}`}
-            />
-          </>
-        )}
-      </LazyRenderWrapper>
-    </>
+    <div>
+      <AdDableWidget />
+      <AdPopinRecommend />
+    </div>
   )
 }
 

--- a/packages/mirror-tv-next/components/story/ad-dable-widget.tsx
+++ b/packages/mirror-tv-next/components/story/ad-dable-widget.tsx
@@ -31,7 +31,7 @@ const AdDableWidget: React.FC = () => {
 
           const dablePluginSrc = '//static.dable.io/dist/plugin.min.js'
           const hasDablePlugin = !!document.querySelector(
-            `script[src="${dablePluginSrc}"]`
+            'script[src*="static.dable.io/dist/plugin.min.js"]'
           )
           if (!hasDablePlugin) {
             const scriptElement = document.createElement('script')

--- a/packages/mirror-tv-next/components/story/ad-dable-widget.tsx
+++ b/packages/mirror-tv-next/components/story/ad-dable-widget.tsx
@@ -1,0 +1,63 @@
+'use client'
+import dynamic from 'next/dynamic'
+
+import styles from './_styles/ad-dable-widget.module.scss'
+
+const LazyRenderWrapper = dynamic(
+  () => import('~/components/shared/lazy-render-wrapper'),
+  {
+    ssr: false,
+  }
+)
+
+const AdDableWidget: React.FC = () => {
+  return (
+    <div className={styles.dableWidgetLast}>
+      <LazyRenderWrapper
+        callbackFn={() => {
+          type DableFunction = ((...args: unknown[]) => void) & {
+            q?: unknown[][]
+          }
+          const dableWindow = window as Window & {
+            dable?: DableFunction
+          }
+
+          if (!dableWindow.dable) {
+            const queuedDable = ((...args: unknown[]) => {
+              ;(queuedDable.q = queuedDable.q || []).push(args)
+            }) as DableFunction
+            dableWindow.dable = queuedDable
+          }
+
+          const dablePluginSrc = '//static.dable.io/dist/plugin.min.js'
+          const hasDablePlugin = !!document.querySelector(
+            `script[src="${dablePluginSrc}"]`
+          )
+          if (!hasDablePlugin) {
+            const scriptElement = document.createElement('script')
+            scriptElement.async = true
+            scriptElement.charset = 'utf-8'
+            scriptElement.src = dablePluginSrc
+            document.head.appendChild(scriptElement)
+          }
+
+          dableWindow.dable?.('setService', 'mnews.tw')
+          dableWindow.dable?.('sendLogOnce')
+          dableWindow.dable?.(
+            'renderWidgetByWidth',
+            'dablewidget_2Xnxwk7d_xXAWmB7G'
+          )
+        }}
+      >
+        <div
+          id="dablewidget_2Xnxwk7d_xXAWmB7G"
+          data-widget_id-pc="2Xnxwk7d"
+          data-widget_id-mo="xXAWmB7G"
+          className="dable-widget-last"
+        />
+      </LazyRenderWrapper>
+    </div>
+  )
+}
+
+export default AdDableWidget

--- a/packages/mirror-tv-next/components/story/ad-dable-widget.tsx
+++ b/packages/mirror-tv-next/components/story/ad-dable-widget.tsx
@@ -10,45 +10,43 @@ const LazyRenderWrapper = dynamic(
   }
 )
 
+type DableFunction = ((...args: unknown[]) => void) & {
+  q?: unknown[][]
+}
+
+function initDableWidget() {
+  const dableWindow = window as Window & {
+    dable?: DableFunction
+  }
+
+  if (!dableWindow.dable) {
+    const queuedDable = ((...args: unknown[]) => {
+      ;(queuedDable.q = queuedDable.q || []).push(args)
+    }) as DableFunction
+    dableWindow.dable = queuedDable
+  }
+
+  const dablePluginSrc = '//static.dable.io/dist/plugin.min.js'
+  const hasDablePlugin = !!document.querySelector(
+    'script[src*="static.dable.io/dist/plugin.min.js"]'
+  )
+  if (!hasDablePlugin) {
+    const scriptElement = document.createElement('script')
+    scriptElement.async = true
+    scriptElement.charset = 'utf-8'
+    scriptElement.src = dablePluginSrc
+    document.head.appendChild(scriptElement)
+  }
+
+  dableWindow.dable?.('setService', 'mnews.tw')
+  dableWindow.dable?.('sendLogOnce')
+  dableWindow.dable?.('renderWidgetByWidth', 'dablewidget_2Xnxwk7d_xXAWmB7G')
+}
+
 const AdDableWidget: React.FC = () => {
   return (
     <div className={styles.dableWidgetLast}>
-      <LazyRenderWrapper
-        callbackFn={() => {
-          type DableFunction = ((...args: unknown[]) => void) & {
-            q?: unknown[][]
-          }
-          const dableWindow = window as Window & {
-            dable?: DableFunction
-          }
-
-          if (!dableWindow.dable) {
-            const queuedDable = ((...args: unknown[]) => {
-              ;(queuedDable.q = queuedDable.q || []).push(args)
-            }) as DableFunction
-            dableWindow.dable = queuedDable
-          }
-
-          const dablePluginSrc = '//static.dable.io/dist/plugin.min.js'
-          const hasDablePlugin = !!document.querySelector(
-            'script[src*="static.dable.io/dist/plugin.min.js"]'
-          )
-          if (!hasDablePlugin) {
-            const scriptElement = document.createElement('script')
-            scriptElement.async = true
-            scriptElement.charset = 'utf-8'
-            scriptElement.src = dablePluginSrc
-            document.head.appendChild(scriptElement)
-          }
-
-          dableWindow.dable?.('setService', 'mnews.tw')
-          dableWindow.dable?.('sendLogOnce')
-          dableWindow.dable?.(
-            'renderWidgetByWidth',
-            'dablewidget_2Xnxwk7d_xXAWmB7G'
-          )
-        }}
-      >
+      <LazyRenderWrapper callbackFn={initDableWidget}>
         <div
           id="dablewidget_2Xnxwk7d_xXAWmB7G"
           data-widget_id-pc="2Xnxwk7d"

--- a/packages/mirror-tv-next/components/story/ad-popin-recommend.tsx
+++ b/packages/mirror-tv-next/components/story/ad-popin-recommend.tsx
@@ -1,0 +1,34 @@
+'use client'
+import dynamic from 'next/dynamic'
+
+import useWindowDimensions from '~/hooks/use-window-dimensions'
+import UiHeadingBordered from '../shared/ui-heading-bordered'
+import styles from './_styles/ad-popin-recommend.module.scss'
+
+const LazyRenderWrapper = dynamic(
+  () => import('~/components/shared/lazy-render-wrapper'),
+  {
+    ssr: false,
+  }
+)
+
+const AdPopinRecommend: React.FC = () => {
+  const { width } = useWindowDimensions()
+
+  if (!width || width < 1200) {
+    return null
+  }
+
+  return (
+    <>
+      <UiHeadingBordered title="每日精選" className={styles.dailySelection} />
+      <div className={styles.popinRecommend}>
+        <LazyRenderWrapper>
+          <div id="_popIn_recommend" className="popin_recommend" />
+        </LazyRenderWrapper>
+      </div>
+    </>
+  )
+}
+
+export default AdPopinRecommend

--- a/packages/mirror-tv-next/components/story/ad-popin-recommend.tsx
+++ b/packages/mirror-tv-next/components/story/ad-popin-recommend.tsx
@@ -1,16 +1,8 @@
 'use client'
-import dynamic from 'next/dynamic'
 
 import useWindowDimensions from '~/hooks/use-window-dimensions'
 import UiHeadingBordered from '../shared/ui-heading-bordered'
 import styles from './_styles/ad-popin-recommend.module.scss'
-
-const LazyRenderWrapper = dynamic(
-  () => import('~/components/shared/lazy-render-wrapper'),
-  {
-    ssr: false,
-  }
-)
 
 const AdPopinRecommend: React.FC = () => {
   const { width } = useWindowDimensions()
@@ -23,9 +15,7 @@ const AdPopinRecommend: React.FC = () => {
     <>
       <UiHeadingBordered title="每日精選" className={styles.dailySelection} />
       <div className={styles.popinRecommend}>
-        <LazyRenderWrapper>
-          <div id="_popIn_recommend" className="popin_recommend" />
-        </LazyRenderWrapper>
+        <div id="_popIn_recommend" className="popin_recommend" />
       </div>
     </>
   )


### PR DESCRIPTION
Summary ￼

Refactored the Dable and popIn ad integration by splitting the monolithic ‎`AdAfterStory` component into two focused components and moving script initialization from the layout level into the components themselves.

Changes ￼

1. Removed Dable ‎`<Script>` from layouts — The inline Dable SDK script was removed from both ‎`story/[slug]/layout.tsx` and ‎`external/[slug]/layout.tsx`. SDK loading is now handled dynamically inside the ad component, with duplicate-script detection to avoid re-injection.

2. Extracted ‎`AdDableWidget` — Handles Dable SDK initialization and widget rendering. Initializes ‎`window.dable` as a queue function if not present, loads ‎`plugin.min.js` only when absent, and calls ‎`setService`, ‎`sendLogOnce`, and ‎`renderWidgetByWidth`. Wrapped with a placeholder height (‎`1050px` desktop / ‎`1800px` mobile) to prevent layout shift during lazy load.

3. Extracted ‎`AdPopinRecommend` — Renders the popIn “每日精選” recommend widget, desktop only (≥1200px). Added ‎`min-height: 344px` placeholder for lazy load spacing.

4. Simplified ‎`AdAfterStory` — Now just composes ‎`<AdDableWidget />` + ‎`<AdPopinRecommend />` with no business logic.

5. Renamed styles — ‎`ad-after-story.module.scss` → ‎`ad-popin-recommend.module.scss`; added new ‎`ad-dable-widget.module.scss`.


Ref

[Dable廣告版位設預設高度與除錯](https://app.asana.com/1/614399484723017/project/1215184739359712/task/1214371553619077?focus=true)