### PR TITLE
refactor(tag): adjust robots indexing and canonical url conditions for tag page

### DIFF
--- a/packages/mirror-tv-next/app/tag/[name]/page.tsx
+++ b/packages/mirror-tv-next/app/tag/[name]/page.tsx
@@ -76,15 +76,15 @@ export async function generateMetadata({
     description = undefined
   }
 
-  const isNoindex = totalCount < 3
+  const isIndex = totalCount >= 5
 
   return {
     metadataBase: new URL(SITE_URL),
     title: `${tagName} - 鏡新聞`,
     description,
-    robots: isNoindex ? { index: false, follow: true } : undefined,
+    robots: { index: isIndex, follow: true },
     alternates: {
-      canonical: canonicalUrl,
+      canonical: isIndex ? canonicalUrl : undefined,
     },
     openGraph: {
       title: `${tagName} - 鏡新聞`,


### PR DESCRIPTION
refactor: adjust robots indexing and canonical url conditions for tag page

## 🎯 Why do we do this?

Adjust the search engine crawler indexing strategy for tag pages. We want to index tag pages only when the total count of posts and external links is greater than 5. This prevents search engines from indexing too many low-quality tag pages with minimal content, thus optimizing the website's overall SEO. Additionally, we only want to specify a canonical URL when the page is eligible for indexing.

## ⚠️ Changes

### Tag Page Metadata Configuration
- **Direction**: Adjust the robots indexing logic and conditional canonical URL settings.
- **Details**:
  - Changed the indexing condition from "do not index (noindex) if total count of posts/externals is less than 3" to "only index if total count is greater than 5".
  - Refactored the robots return value from a conditional ternary to directly returning the robots configuration object.
  - Updated the canonical URL setting to only include the URL when the page is indexed, avoiding setting a canonical URL on non-indexed tag pages.

## 🧪 Testing Steps

### Test Case 1: Validate robots and canonical URL properties on tag pages

1. Navigate to a tag page that has 6 or more posts/external links.
2. Inspect the HTML source code of the page to check the robots meta tag and the canonical link tag.
3. **Expected Result**: The robots tag should allow indexing (e.g., `content="index, follow"`) and the canonical URL should be present.
4. Navigate to a tag page that has 5 or fewer posts/external links.
5. Inspect the HTML source code of the page to check the robots meta tag and the canonical link tag.
6. **Expected Result**: The robots tag should prevent indexing (e.g., `content="noindex, follow"`) and the canonical URL should not be present.

## Task Link
[收錄少於5篇（不含5篇）文章的tag頁設noindex並移除canonical](https://app.asana.com/1/614399484723017/project/1215184739359712/task/1214066371520014)
