### PR TITLE
fix: prevent rendering of YouTube block without a valid youtubeId

### DIFF
--- a/packages/mirror-tv-next/components/story/api-data-renderer/block-renderer/youtube-block.tsx
+++ b/packages/mirror-tv-next/components/story/api-data-renderer/block-renderer/youtube-block.tsx
@@ -30,7 +30,7 @@ const YoutubeBlock = ({
   let youtubeId = rawYoutubeId?.trim() || ''
 
   if (youtubeId.includes('youtube.com') || youtubeId.includes('youtu.be')) {
-    youtubeId = extractYoutubeId(youtubeId) ?? ''
+    youtubeId = extractYoutubeId(youtubeId)
   } else {
     youtubeId = youtubeId.replace(/^\/+|\/+$/g, '')
   }

--- a/packages/mirror-tv-next/components/story/api-data-renderer/block-renderer/youtube-block.tsx
+++ b/packages/mirror-tv-next/components/story/api-data-renderer/block-renderer/youtube-block.tsx
@@ -38,6 +38,9 @@ const YoutubeBlock = ({
     youtubeId = youtubeId.replace(/^\/+|\/+$/g, '')
   }
 
+  // 沒有有效 youtubeId 就不渲染，避免 <amp-youtube> 缺 data-videoid 而 AMP 驗證失敗
+  if (!youtubeId) return null
+
   return (
     <div className={styles.youtubeContainer}>
       {isAmp ? (

--- a/packages/mirror-tv-next/components/story/api-data-renderer/block-renderer/youtube-block.tsx
+++ b/packages/mirror-tv-next/components/story/api-data-renderer/block-renderer/youtube-block.tsx
@@ -30,15 +30,11 @@ const YoutubeBlock = ({
   let youtubeId = rawYoutubeId?.trim() || ''
 
   if (youtubeId.includes('youtube.com') || youtubeId.includes('youtu.be')) {
-    const extractedId = extractYoutubeId(youtubeId)
-    if (extractedId) {
-      youtubeId = extractedId
-    }
+    youtubeId = extractYoutubeId(youtubeId) ?? ''
   } else {
     youtubeId = youtubeId.replace(/^\/+|\/+$/g, '')
   }
 
-  // 沒有有效 youtubeId 就不渲染，避免 <amp-youtube> 缺 data-videoid 而 AMP 驗證失敗
   if (!youtubeId) return null
 
   return (


### PR DESCRIPTION
Changed

1. validate  youtubeId to render amp tag



Ref
[amp-youtube 標記異常](https://app.asana.com/1/614399484723017/project/1215184739359712/task/1213892930522001?focus=true)