### PR TITLE
feat(seo): add canonical url metadata to multiple pages

### DIFF
--- a/packages/mirror-tv-next/app/anchorperson/[slug]/page.tsx
+++ b/packages/mirror-tv-next/app/anchorperson/[slug]/page.tsx
@@ -83,6 +83,9 @@ export async function generateMetadata({
     metadataBase: new URL(SITE_URL),
     title: `${singleAnchor?.name} - 鏡新聞`,
     description: description !== '' ? description : META_DESCRIPTION,
+    alternates: {
+      canonical: `${SITE_URL}/anchorperson/${params.slug}`,
+    },
     openGraph: {
       title: `${singleAnchor?.name} - 鏡新聞`,
       description: description !== '' ? description : META_DESCRIPTION,

--- a/packages/mirror-tv-next/app/anchorperson/page.tsx
+++ b/packages/mirror-tv-next/app/anchorperson/page.tsx
@@ -22,6 +22,9 @@ export const revalidate = GLOBAL_CACHE_SETTING
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
   title: '鏡主播 - 鏡新聞',
+  alternates: {
+    canonical: `${SITE_URL}/anchorperson`,
+  },
   openGraph: {
     title: '鏡主播 - 鏡新聞',
     images: {

--- a/packages/mirror-tv-next/app/category/[slug]/page.tsx
+++ b/packages/mirror-tv-next/app/category/[slug]/page.tsx
@@ -81,6 +81,9 @@ export async function generateMetadata({
     return {
       metadataBase: new URL(SITE_URL),
       title: '分類 - 鏡新聞',
+      alternates: {
+        canonical: `${SITE_URL}/category/${slug}`,
+      },
       openGraph: {
         title: '分類 - 鏡新聞',
         images: {
@@ -184,6 +187,9 @@ export async function generateMetadata({
   return {
     metadataBase: new URL(SITE_URL),
     title: `${categoryData.name} - 鏡新聞`,
+    alternates: {
+      canonical: `${SITE_URL}/category/${slug}`,
+    },
     openGraph: {
       title: `${categoryData.name} - 鏡新聞`,
       images: {

--- a/packages/mirror-tv-next/app/category/video/page.tsx
+++ b/packages/mirror-tv-next/app/category/video/page.tsx
@@ -40,6 +40,9 @@ export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
   title: '影音 - 鏡新聞',
   description: '最新最熱門，深入淺出的影音新聞。',
+  alternates: {
+    canonical: `${SITE_URL}/category/video`,
+  },
   openGraph: {
     title: '影音 - 鏡新聞',
     description: '最新最熱門，深入淺出的影音新聞。',

--- a/packages/mirror-tv-next/app/ombuds/page.tsx
+++ b/packages/mirror-tv-next/app/ombuds/page.tsx
@@ -13,6 +13,9 @@ const GPTAd = dynamic(() => import('~/components/ads/gpt/gpt-ad'))
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
   title: '公評人專區 - 鏡新聞',
+  alternates: {
+    canonical: `${SITE_URL}/ombuds`,
+  },
   openGraph: {
     title: '公評人專區 - 鏡新聞',
     images: {

--- a/packages/mirror-tv-next/app/page.tsx
+++ b/packages/mirror-tv-next/app/page.tsx
@@ -5,11 +5,15 @@ import styles from '~/styles/pages/page.module.scss'
 import { GPTPlaceholderMobile } from '~/components/ads/gpt/gpt-placeholder'
 import { GPTPlaceholderDesktop } from '~/components/ads/gpt/gpt-placeholder'
 import GptPopup from '~/components/ads/gpt/gpt-popup'
-import { GLOBAL_CACHE_SETTING } from '~/constants/environment-variables'
+import {
+  GLOBAL_CACHE_SETTING,
+  SITE_URL,
+} from '~/constants/environment-variables'
 import TopicList from '~/components/homepage/topic-list'
 import ShowList from '~/components/homepage/show-list-init'
 import LatestAndEditorChoicesWithLive from '~/components/homepage/latest-and-editor-choices-with-live'
 import { getTopicVideo } from '~/app/_actions/homepage/topic-video'
+import type { Metadata } from 'next'
 
 const GPTAd = dynamic(() => import('~/components/ads/gpt/gpt-ad'))
 const PromotionVideoList = dynamic(
@@ -17,6 +21,12 @@ const PromotionVideoList = dynamic(
 )
 
 export const revalidate = GLOBAL_CACHE_SETTING
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: SITE_URL,
+  },
+}
 
 export default async function Home() {
   const { data: homepageData } = await getTopicVideo()

--- a/packages/mirror-tv-next/app/schedule/page.tsx
+++ b/packages/mirror-tv-next/app/schedule/page.tsx
@@ -20,6 +20,9 @@ export const revalidate = GLOBAL_CACHE_SETTING
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
   title: '節目表 - 鏡新聞',
+  alternates: {
+    canonical: `${SITE_URL}/schedule`,
+  },
   openGraph: {
     title: '節目表 - 鏡新聞',
     images: {

--- a/packages/mirror-tv-next/app/show/[slug]/page.tsx
+++ b/packages/mirror-tv-next/app/show/[slug]/page.tsx
@@ -162,6 +162,9 @@ export async function generateMetadata({
     ...(data.metadataBase && { metadataBase: data.metadataBase }),
     ...(data.title && { title: data.title }),
     ...(data.description && { description: data.description }),
+    alternates: {
+      canonical: `${SITE_URL}/show/${slug}`,
+    },
     openGraph: {
       ...(data.openGraph?.title && { title: data.openGraph.title }),
       ...(data.openGraph?.description && {

--- a/packages/mirror-tv-next/app/topic/[slug]/page.tsx
+++ b/packages/mirror-tv-next/app/topic/[slug]/page.tsx
@@ -78,6 +78,9 @@ export async function generateMetadata({
     metadataBase: new URL(SITE_URL),
     title: `${singleTopic?.title} - 鏡新聞`,
     description: description !== '' ? description : META_DESCRIPTION,
+    alternates: {
+      canonical: `${SITE_URL}/topic/${params.slug}`,
+    },
     openGraph: {
       title: `${singleTopic?.title} - 鏡新聞`,
       description: description !== '' ? description : META_DESCRIPTION,

--- a/packages/mirror-tv-next/app/topic/page.tsx
+++ b/packages/mirror-tv-next/app/topic/page.tsx
@@ -18,6 +18,9 @@ export const revalidate = GLOBAL_CACHE_SETTING
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
   title: '專題 - 鏡新聞',
+  alternates: {
+    canonical: `${SITE_URL}/topic`,
+  },
   openGraph: {
     title: '專題 - 鏡新聞',
     images: {


### PR DESCRIPTION
## Task Link
[全站除noindex頁面外加canonical標籤](https://app.asana.com/1/614399484723017/project/1215184739359712/task/1213800345670565?focus=true)

## 🎯 Why do we do this?

Add canonical URL settings to the metadata of multiple key pages/routes (including homepage, schedule, ombuds, topic, show, category, and anchorperson pages). This ensures that search engines recognize the preferred version of these URLs, preventing duplicate content issues and improving the website's overall SEO.

## ⚠️ Changes

### SEO Metadata Enhancement
- **Direction**: Add canonical URL fields to the metadata configuration across multiple route pages.
- **Details**:
  - Added absolute canonical URLs to static page routes (homepage, schedule page, ombuds page, topic list page, anchorperson list page).
  - Added dynamic absolute canonical URLs to dynamic page routes (single show page, single topic page, single category page, single anchorperson page).

## 🧪 Testing Steps

### Test Case 1: Verify canonical URL injection in HTML headers

1. Navigate to the homepage, schedule page, ombuds page, topic list page, or anchorperson list page.
2. Inspect the HTML source code of the page.
3. **Expected Result**: The canonical link tag points to the correct absolute URL for that page.
4. Navigate to a dynamic single show page, single topic page, single category page, or single anchorperson page.
5. Inspect the HTML source code of the page.
6. **Expected Result**: The canonical link tag points to the correct dynamic absolute URL (e.g. including the corresponding slug or name).