### PR TITLE
refactor(story): use semantic time tags for article dates

### DIFF
--- a/packages/mirror-tv-next/app/external/[slug]/page.tsx
+++ b/packages/mirror-tv-next/app/external/[slug]/page.tsx
@@ -306,13 +306,22 @@ const ExternalPage = async (props: ExternalPageTypes) => {
     '臺北時間'
   )
 
+  const publishDateTime = formateDateAtTaipei(
+    new Date(publishTime),
+    'YYYY-MM-DDTHH:mm:ss+08:00'
+  )
+
   const shouldShowAds =
     !(categories?.length === 1 && categories?.[0]?.slug === 'ombuds') &&
     !FILTERED_SLUG.includes(params.slug)
 
-  const updatedTime = updatedAt
-    ? formateDateAtTaipei(new Date(updatedAt), 'YYYY.MM.DD HH:mm', '臺北時間')
-    : ''
+  const updatedTime =
+    updatedAt &&
+    formateDateAtTaipei(new Date(updatedAt), 'YYYY.MM.DD HH:mm', '臺北時間')
+
+  const updatedDateTime =
+    updatedAt &&
+    formateDateAtTaipei(new Date(updatedAt), 'YYYY-MM-DDTHH:mm:ss+08:00')
 
   // 處理 content_original
   // 1. 先移除與 heroCaption 重複的第一段
@@ -356,9 +365,11 @@ const ExternalPage = async (props: ExternalPageTypes) => {
             heroVideo={undefined}
           />
         )}
+
         <ArticleInfo
           title={title}
           publishTime={publishTimeTaipei}
+          publishDateTime={publishDateTime}
           category={
             category
               ? { title: category.name, slug: category.slug }
@@ -380,7 +391,10 @@ const ExternalPage = async (props: ExternalPageTypes) => {
             className={styles.externalContent}
             dangerouslySetInnerHTML={{ __html: processedContent ?? '' }}
           />
-          {updatedTime && <ArticleUpdateTime updateTime={updatedTime} />}
+          <ArticleUpdateTime
+            updateTime={updatedTime}
+            updateDateTime={updatedDateTime}
+          />
           {!!tags.length && <ArticleTagList tags={tags} />}
         </section>
         <AdTvAdminMobileBanner />

--- a/packages/mirror-tv-next/app/story/[slug]/page.tsx
+++ b/packages/mirror-tv-next/app/story/[slug]/page.tsx
@@ -327,6 +327,12 @@ const StoryPage = async (props: StoryPageTypes) => {
     'YYYY.MM.DD HH:mm',
     '臺北時間'
   )
+
+  const publishDateTime = formateDateAtTaipei(
+    new Date(publishTime),
+    'YYYY-MM-DDTHH:mm:ss+08:00'
+  )
+
   const lists = resolveRenderedStoryLists(storyData)
   const categoriesRendered = lists.categories
   const writersRendered = lists.writers
@@ -338,9 +344,13 @@ const StoryPage = async (props: StoryPageTypes) => {
       categoriesRendered[0]?.slug === 'ombuds'
     ) && !FILTERED_SLUG.includes(params.slug)
 
-  const updatedTime = updatedAt
-    ? formateDateAtTaipei(new Date(updatedAt), 'YYYY.MM.DD HH:mm', '臺北時間')
-    : ''
+  const updatedTime =
+    updatedAt &&
+    formateDateAtTaipei(new Date(updatedAt), 'YYYY.MM.DD HH:mm', '臺北時間')
+
+  const updatedDateTime =
+    updatedAt &&
+    formateDateAtTaipei(new Date(updatedAt), 'YYYY-MM-DDTHH:mm:ss+08:00')
 
   const hasBrief = doesHaveBrief(handleApiData(briefApiData))
 
@@ -381,6 +391,7 @@ const StoryPage = async (props: StoryPageTypes) => {
         <ArticleInfo
           title={title}
           publishTime={publishTimeTaipei}
+          publishDateTime={publishDateTime}
           category={categoriesRendered[0]}
           writers={writersRendered}
           photographers={photographers}
@@ -397,7 +408,10 @@ const StoryPage = async (props: StoryPageTypes) => {
             isStoryBrief={false}
           />
           {!!download?.length && <UiDownload downloads={download} />}
-          {updatedTime && <ArticleUpdateTime updateTime={updatedTime} />}
+          <ArticleUpdateTime
+            updateTime={updatedTime}
+            updateDateTime={updatedDateTime}
+          />
           {!!tagsRendered?.length && <ArticleTagList tags={tagsRendered} />}
         </section>
         <AdTvAdminMobileBanner />

--- a/packages/mirror-tv-next/components/story/article-info.tsx
+++ b/packages/mirror-tv-next/components/story/article-info.tsx
@@ -5,7 +5,8 @@ import ShareButton from './share-button'
 
 type ArticleHeroImageProps = {
   title: string
-  publishTime: string
+  publishTime?: string
+  publishDateTime?: string
   category: SinglePost['categories'][0]
   writers: SinglePost['writers']
   photographers: SinglePost['photographers']
@@ -19,6 +20,7 @@ type ArticleHeroImageProps = {
 export default function ArticleInfo({
   title,
   publishTime,
+  publishDateTime,
   category,
   writers,
   photographers,
@@ -47,8 +49,10 @@ export default function ArticleInfo({
     <>
       <section className={styles.categoryAndPublishTime}>
         <span className={styles.category}>{category?.title}</span>
-        {publishTime && (
-          <span className="amp-pub-cat-publishTime">{publishTime}</span>
+        {publishTime && publishDateTime && (
+          <time dateTime={publishDateTime} className="amp-pub-cat-publishTime">
+            {publishTime}
+          </time>
         )}
       </section>
       <h1 className={styles.title}>{title}</h1>

--- a/packages/mirror-tv-next/components/story/article-update-time.tsx
+++ b/packages/mirror-tv-next/components/story/article-update-time.tsx
@@ -2,16 +2,22 @@ import React from 'react'
 import styles from './_styles/article-update-time.module.scss'
 
 interface ArticleUpdateTimeProps {
-  updateTime: string
+  updateTime: string | null
+  updateDateTime: string | null
 }
 
 const ArticleUpdateTime: React.FC<ArticleUpdateTimeProps> = ({
   updateTime,
+  updateDateTime,
 }) => {
+  if (!updateTime || !updateDateTime) return null
+
   return (
     <div className={styles.updateTime}>
       <span className={styles.updateTimeTitle}>更新時間</span>
-      <span className={styles.updateTimeTime}>{updateTime}</span>
+      <time dateTime={updateDateTime} className={styles.updateTimeTime}>
+        {updateTime}
+      </time>
     </div>
   )
 }

--- a/packages/mirror-tv-next/utils/date-handler.ts
+++ b/packages/mirror-tv-next/utils/date-handler.ts
@@ -11,7 +11,12 @@ function formateDateAtTaipei(
   dayjs.extend(timezone)
   dayjs.tz.setDefault('Asia/Taipei')
   const taipeiTime = dayjs(date).tz('Asia/Taipei').format(formateString)
-  return `${taipeiTime} ${suffixStr}`
+
+  if (suffixStr) {
+    return `${taipeiTime} ${suffixStr}`
+  }
+
+  return taipeiTime
 }
 
 function getNextThursdayNoon() {


### PR DESCRIPTION
Asana tasks: [story/external發布與更新時間改<time>標籤](https://app.asana.com/1/614399484723017/project/1215184739359712/task/1213729828067501)

## 🎯 Why

Update the HTML structure of the article and external article pages to use semantic `<time>` tags with the `dateTime` attribute instead of generic elements, aligning with modern web standards to improve Search Engine Optimization (SEO) and web accessibility.


## ⚠️ Changes

### Time Formatting Utility Adjustment
- **Refactoring Direction**: Extend the capability of the date formatting utility function
- **Details**:
  - Adjusted the Taipei time formatting function so that it does not append a trailing space when no suffix string is provided, enabling the generation of standard ISO-8601 formatted date-time strings.

### Component Semantic Enhancements
- **Refactoring Direction**: Optimize component markup structure and extend prop definitions
- **Details**:
  - Added an optional ISO date-time prop to the article info component and replaced the tag for publish time with a semantic `<time>` tag bound to the `dateTime` attribute.
  - Added an optional ISO date-time prop to the article update time component and replaced the update time element with a semantic `<time>` tag bound to the `dateTime` attribute.
  - Introduced conditional rendering checks to ensure that the update time component is not rendered if values are empty or incomplete.

### Page Date Integration
- **Refactoring Direction**: Integrate semantic time tags in general article and external article pages
- **Details**:
  - Generated standard ISO-8601 formatted date-time strings (YYYY-MM-DDTHH:mm:ss+08:00) for the Taipei timezone during server-side rendering in both general and external article pages.
  - Passed the generated ISO date-time strings to their respective date presentation components to bind them to the `dateTime` attributes of the semantic `<time>` tags.


## 🧪 Test Steps

### Test Case 1: Date Formatting Utility Test (Corresponds to Time Formatting Utility Adjustment)

1. Call the date formatting function, passing `new Date('2026-06-10T13:34:52+08:00')` and the format string `YYYY-MM-DDTHH:mm:ss+08:00` without any suffix parameter.
2. **Expected Result**: The returned formatted string is `2026-06-10T13:34:52+08:00` with no trailing spaces.

### Test Case 2: Article Page Semantic Tag Check (Corresponds to Component Semantic Enhancements & Page Date Integration)

1. Open any general article page in the browser.
2. Inspect the publish time HTML element using browser developer tools.
3. **Expected Result**: The publish time is rendered using a `<time>` tag with a `dateTime` attribute containing the article's ISO-8601 formatted publish date-time (e.g., `2026-06-10T13:34:52+08:00`).
4. Inspect the update time HTML element using browser developer tools.
5. **Expected Result**: The update time is rendered using a `<time>` tag with a `dateTime` attribute containing the article's ISO-8601 formatted update date-time.

### Test Case 3: External Article Page Semantic Tag Check (Corresponds to Component Semantic Enhancements & Page Date Integration)

1. Open any external article page in the browser.
2. Inspect the publish and update time HTML elements using browser developer tools.
3. **Expected Result**: Both publish time and update time are rendered using `<time>` tags with the correct ISO-8601 `dateTime` attribute values.
