### PR TITLE
chore(ads): adjust PC_HD and MB_M1 ad slot sizes

### DIFF
--- a/packages/mirror-tv-next/constants/ads.ts
+++ b/packages/mirror-tv-next/constants/ads.ts
@@ -68,10 +68,8 @@ const GPT_UNITS: GPTUnits = {
     PC_HD: {
       adUnit: 'mnews_masthead_top_970x400',
       adSize: [
-        [970, 400],
         [970, 250],
         [970, 90],
-        [1, 1],
       ],
     },
   },
@@ -173,11 +171,7 @@ const GPT_UNITS: GPTUnits = {
     },
     MB_M1: {
       adUnit: 'mnews_m_article_top_300x250',
-      adSize: [
-        [300, 250],
-        [336, 280],
-        [1, 1],
-      ],
+      adSize: [[300, 250]],
     },
     MB_M2: {
       adUnit: 'mnews_m_article_middle_300x250',


### PR DESCRIPTION
## Asana Task
[全站topbanner廣告版位CLS優化](https://app.asana.com/1/614399484723017/project/1180545429058675/task/1215475789423931?focus=true)

## 🎯 Why are we doing this

Align with current advertising strategy by removing unused ad slot sizes to ensure correct ad delivery and clean layout.

## ⚠️ Changes

### GPT Ad Unit Size Configuration
- **Direction**: Configuration adjustment
- **Content**:
  - Adjust PC masthead top ad slot sizes: remove `970x400` and `1x1` size configurations, keeping the remaining sizes.
  - Adjust mobile article top ad slot sizes: remove `336x280` and `1x1` size configurations, leaving only `300x250`.

## 🧪 Testing Steps

### Test Case 1: GPT Ad Unit Size Verification

1. Start the application and navigate to the web page.
2. Inspect the loaded ad module configurations and request parameters.
3. **Expected Result**:
   - The PC masthead top ad unit supports only `970x250` and `970x90` sizes; `970x400` or `1x1` should not be loaded.
   - The mobile article top ad unit supports only `300x250` size; `336x280` or `1x1` should not be loaded.
