### PR TITLE
fix(miso-pageview): handle undefined MisoClient on window

### DIFF
--- a/packages/mirror-tv-next/app/layout.tsx
+++ b/packages/mirror-tv-next/app/layout.tsx
@@ -198,7 +198,6 @@ export default async function RootLayout({
       </Script>
       <Script
         async
-        strategy="beforeInteractive"
         src="https://cdn.jsdelivr.net/npm/@miso.ai/client-sdk@1.11.4/dist/umd/miso.min.js"
       />
       <CompassFit />

--- a/packages/mirror-tv-next/components/tracking/miso-pageview.tsx
+++ b/packages/mirror-tv-next/components/tracking/miso-pageview.tsx
@@ -7,6 +7,10 @@ export default function MisoPageView({ productIds }: { productIds: string }) {
     const misocmd = window.misocmd || (window.misocmd = [])
     misocmd.push(() => {
       const MisoClient = window.MisoClient
+      if (!MisoClient) {
+        return
+      }
+
       const client = new MisoClient(MISO_API_KEY)
       client.api.interactions.upload({
         type: 'product_detail_page_view',


### PR DESCRIPTION
## Asana Task
[【電視web】survey-廣告版位間歇性完全無法載入](https://app.asana.com/1/614399484723017/project/1215753750830181/task/1215696572612358)

## 🎯 為什麼要這樣做

當網頁中的 MisoClient 尚未載入完成或未定義時，若直接呼叫其 interaction 追蹤，會導致 JavaScript 執行錯誤。此修改旨在確保 MisoClient 存在時才執行相關的 interaction 上傳邏輯，提升追蹤元件的穩定度。

## ⚠️ 修改的內容

### Miso 頁面瀏覽追蹤
- **修改方向**：修復邏輯錯誤與提升穩定性
- **內容**：
  - 於效果載入時（useEffect），優先檢查全域 window 中是否存在 Miso 追蹤客戶端
  - 若 Miso 追蹤客戶端尚未載入，則直接返回，避免執行後續推播邏輯時拋出錯誤
  - 調整變量宣告的執行順序，將實例化與載入檢查移至最前

## 🧪 測試步驟

### 測試案例 1：Miso 追蹤客戶端已載入時的行為
1. 開啟包含頁面瀏覽追蹤的網頁，並確保 window.MisoClient 已正確載入
2. 觀察瀏覽器主控台與網路請求
3. **預期結果**：追蹤客戶端能順利執行 interaction 的 upload 請求，無任何 JS 錯誤

### 測試案例 2：Miso 追蹤客戶端未載入時的行為
1. 開啟包含頁面瀏覽追蹤的網頁，並模擬 window.MisoClient 為 undefined 的狀態
2. 觀察瀏覽器主控台
3. **預期結果**：網頁載入正常，主控台不會拋出相關的錯誤
