### PR TITLE
feat(story): add VideoObject structured data for YouTube blocks

### DIFF
--- a/packages/mirror-tv-next/app/story/[slug]/page.tsx
+++ b/packages/mirror-tv-next/app/story/[slug]/page.tsx
@@ -124,13 +124,13 @@ function generateStoryJsonLds(
   const keywords = lists.tags.map((tag) => tag.name).join(', ')
 
   const jsonLdBreadcrumbList = {
-    '@context': 'http://schema.org/',
+    '@context': 'https://schema.org',
     '@type': 'BreadcrumbList',
     itemListElement: generateBreadcrumbList(storyData, pageUrl, lists),
   }
 
   const jsonLdNewsArticle = {
-    '@context': 'https://schema.org/',
+    '@context': 'https://schema.org',
     '@type': 'NewsArticle',
     mainEntityOfPage: {
       '@type': 'WebPage',
@@ -162,7 +162,7 @@ function generateStoryJsonLds(
   let jsonLdPerson
   if (writerRendered?.length) {
     jsonLdPerson = {
-      '@context': 'http://schema.org/',
+      '@context': 'https://schema.org',
       '@type': 'Person',
       name: writerRendered?.[0]?.name,
       brand: {
@@ -404,6 +404,7 @@ const StoryPage = async (props: StoryPageTypes) => {
         {hasBrief && <ArticleBrief brief={handleApiData(briefApiData)} />}
         <section className={styles.contentWrapper}>
           <ApiDataRenderer
+            postId={id}
             contentData={contentApiData ?? ''}
             isStoryBrief={false}
           />

--- a/packages/mirror-tv-next/components/story/api-data-renderer/renderer.tsx
+++ b/packages/mirror-tv-next/components/story/api-data-renderer/renderer.tsx
@@ -1,3 +1,4 @@
+import errors from '@twreporter/errors'
 import BlockquoteBlock from './block-renderer/blockquote-block'
 import HeadersBlock from './block-renderer/headers-block'
 import OrderListBlock from './block-renderer/order-list-block'
@@ -133,19 +134,29 @@ import ImageBlock from './block-renderer/image-block'
 import UnstyledBlock from './block-renderer/unstyled-block'
 import dynamic from 'next/dynamic'
 import { STATIC_BASE_URL } from '~/constants/endpoint-config'
+import { getClient } from '~/apollo-client'
+import {
+  fetchPostVideoObjects,
+  type PostVideoObjects,
+} from '~/graphql/query/video-object'
+
 const GPTAd = dynamic(() => import('~/components/ads/gpt/gpt-ad'))
 
 type ApiDataRendererPropsType = {
+  postId?: string
   contentData: string | ApiData
   isStoryBrief?: boolean
 }
 
-const ApiDataRenderer = ({
+const ApiDataRenderer = async ({
+  postId,
   contentData,
   isStoryBrief,
 }: ApiDataRendererPropsType) => {
   // Handle both string and already-parsed object cases
   let parsedContentData: ApiData
+  let fetchVideoObjectBySlugResponse: PostVideoObjects['post'] | null = null
+
   if (typeof contentData === 'string') {
     try {
       parsedContentData = JSON.parse(contentData)
@@ -170,8 +181,56 @@ const ApiDataRenderer = ({
     parsedContentData?.splice(4, 0, newObject)
   }
 
+  if (
+    postId &&
+    parsedContentData?.some((block) => block.type === ApiDataBlockType.Youtube)
+  ) {
+    try {
+      const client = getClient()
+      const { data } = await client.query<PostVideoObjects>({
+        query: fetchPostVideoObjects,
+        variables: {
+          id: postId,
+        },
+      })
+      fetchVideoObjectBySlugResponse = data?.post
+    } catch (error) {
+      const annotatingError = errors.helpers.wrap(
+        error,
+        'UnhandledError',
+        'Error occurs while fetching VideoObject by id'
+      )
+
+      console.error(
+        JSON.stringify({
+          severity: 'ERROR',
+          message: errors.helpers.printAll(annotatingError, {
+            withStack: false,
+            withPayload: true,
+          }),
+        })
+      )
+    }
+  }
   return (
     <article className={styles.apiDataArticle}>
+      {fetchVideoObjectBySlugResponse?.videoObjects &&
+        fetchVideoObjectBySlugResponse.videoObjects.length > 0 && (
+          <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{
+              __html: JSON.stringify(
+                fetchVideoObjectBySlugResponse.videoObjects.map((vo) => {
+                  return {
+                    ...vo,
+                    '@context': 'https://schema.org',
+                    '@type': 'VideoObject',
+                  }
+                })
+              ).replace(/</g, '\\\\u003c'),
+            }}
+          />
+        )}
       {parsedContentData?.map((apiDataBlock) => {
         switch (apiDataBlock.type) {
           case ApiDataBlockType.Unstyled:

--- a/packages/mirror-tv-next/graphql/query/video-object.ts
+++ b/packages/mirror-tv-next/graphql/query/video-object.ts
@@ -1,0 +1,24 @@
+import { VideoObject } from 'schema-dts'
+import gql from 'graphql-tag'
+
+export type PostVideoObjects = {
+  post: {
+    id: string
+    slug: string
+    state: string
+    videoObjects: VideoObject[] | null // JSON scalar
+  }
+}
+
+const fetchPostVideoObjects = gql`
+  query fetchPostVideoObjects($id: ID!) {
+    post(where: { id: $id }) {
+      id
+      slug
+      state
+      videoObjects
+    }
+  }
+`
+
+export { fetchPostVideoObjects }

--- a/packages/mirror-tv-next/package.json
+++ b/packages/mirror-tv-next/package.json
@@ -49,6 +49,7 @@
     "concurrently": "^9.2.1",
     "eslint": "^8",
     "eslint-config-next": "14.0.3",
+    "schema-dts": "^2.0.0",
     "typescript": "^5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8537,6 +8537,18 @@ scheduler@^0.23.0:
   dependencies:
     loose-envify "^1.1.0"
 
+schema-dts-lib@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/schema-dts-lib/-/schema-dts-lib-1.0.0.tgz#e10f1e06604fb6c5dcf2d7d56993447a6139364a"
+  integrity sha512-9MEO5vpQH9JdBioUupqluzxSYxPLjhmqRUudk15adUl/ypnRsM2/M1kN3AmVJQeG7nZqcL68H8JlGqQQT6vy9A==
+
+schema-dts@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/schema-dts/-/schema-dts-2.0.0.tgz#9b2550e9e6d5230773376b27615c756226609b6e"
+  integrity sha512-t7NoCy3Rn5GHGx6p7s1qIYK/AeIb8ZxJNR9WUNFkwMv2CiiGZBmqqYWc2FlZVm5ZbiHMY4OvBWhj7QtyrFO2Jw==
+  dependencies:
+    schema-dts-lib "^1.0.0"
+
 semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"


### PR DESCRIPTION
## Asana Task
[article JSON-LD加上VideoObject](https://app.asana.com/1/614399484723017/project/1215753750830181/task/1215108006613498)

## 🎯 為什麼要這樣做

為了優化搜尋引擎最佳化 (SEO) 以及加強網頁的結構化資料 (Structured Data)，特別是針對文章內容中所嵌入的 YouTube 影片區塊。本 PR 在系統中引入 `schema-dts`，為文章內部的 YouTube 影片生成對應的 `VideoObject` 結構化資料 (JSON-LD)，藉此提升文章在 Google 搜尋結果中的影音曝光率與富媒體搜尋結果 (Rich Results) 呈現。

## ⚠️ 修改的內容

### [結構化資料支援]
- **修改方向**：引入結構化資料定義庫，並規範現有的 JSON-LD 命名空間協定。
- **內容**：
  - 新增 `schema-dts` 相依套件，提供規範的結構化資料型別支援
  - 將文章頁面中原本使用的 `@context` 協定由舊版不帶 SSL 且有斜尾線的格式統一改為新版 `https://schema.org`

### [YouTube 影片區塊 JSON-LD 注入]
- **修改方向**：為文章內的 YouTube 區塊動態注入結構化資料。
- **內容**：
  - 新增 GraphQL 查詢，支援依文章 ID 獲取其關聯的影片結構化 JSON 資料
  - 將文章內容渲染元件轉換為非同步伺服器元件，並依據傳入的 `postId` 查詢影片資料
  - 當文章中存在 YouTube 區塊且影片資料存在時，動態渲染並注入影片的結構化 JSON-LD 腳本
  - 將文章的 ID 作為 `postId` 傳入文章內容渲染元件中

## 🧪 測試步驟

### 測試案例 1：YouTube 影片區塊 JSON-LD 注入驗證
1. 開啟任一篇包含 YouTube 影片區塊的文章頁面。
2. 檢視網頁原始碼或使用瀏覽器開發者工具檢查 DOM。
3. **預期結果**：頁面中除了原本的 YouTube 播放器外，應包含指定 ID 的 `application/ld+json` 標籤，且內容包含正確的 `VideoObject` 結構，其 `@context` 應為 `https://schema.org` 且 `@type` 應為 `VideoObject`。

### 測試案例 2：無影片文章的渲染驗證
1. 開啟任一篇不包含任何影片或 YouTube 區塊的文章頁面。
2. 檢視網頁原始碼。
3. **預期結果**：網頁應能正常渲染，且不會注入影片結構化標籤，主控台無任何錯誤。
