### PR TITLE
fix(youtube-block): improve YouTube ID extraction and iframe source formatting

### DIFF
--- a/packages/mirror-tv-next/components/story/api-data-renderer/block-renderer/youtube-block.tsx
+++ b/packages/mirror-tv-next/components/story/api-data-renderer/block-renderer/youtube-block.tsx
@@ -33,8 +33,8 @@ const YoutubeBlock = ({
     youtubeId = extractYoutubeId(youtubeId)
   } else {
     youtubeId = youtubeId.replace(/^\/+|\/+$/g, '')
+    youtubeId = youtubeId.split(/[?&]/)[0].slice(0, 11) // 只取前 11 碼（YouTube ID 固定長度）
   }
-
   if (!youtubeId) return null
 
   return (
@@ -49,7 +49,8 @@ const YoutubeBlock = ({
         ></amp-youtube>
       ) : (
         <iframe
-          src={`https://www.youtube.com/embed/${youtubeId}?si=${youtubeDescription}`}
+          src={`https://www.youtube.com/embed/${youtubeId}
+            ${youtubeDescription ? `?si=${youtubeDescription}` : ''}`}
           title={youtubeDescription}
           className={styles.youtubeIframe}
         />

--- a/packages/mirror-tv-next/components/story/api-data-renderer/block-renderer/youtube-block.tsx
+++ b/packages/mirror-tv-next/components/story/api-data-renderer/block-renderer/youtube-block.tsx
@@ -36,6 +36,9 @@ const YoutubeBlock = ({
     youtubeId = youtubeId.split(/[?&]/)[0].slice(0, 11) // 只取前 11 碼（YouTube ID 固定長度）
   }
   if (!youtubeId) return null
+  const youtubeUrl = `https://www.youtube.com/embed/${youtubeId}${
+    youtubeDescription ? `?si=${youtubeDescription}` : ''
+  }`
 
   return (
     <div className={styles.youtubeContainer}>
@@ -49,8 +52,7 @@ const YoutubeBlock = ({
         ></amp-youtube>
       ) : (
         <iframe
-          src={`https://www.youtube.com/embed/${youtubeId}
-            ${youtubeDescription ? `?si=${youtubeDescription}` : ''}`}
+          src={youtubeUrl}
           title={youtubeDescription}
           className={styles.youtubeIframe}
         />


### PR DESCRIPTION
Changed

1. Sanitize raw YouTube IDs — When youtubeId is not a full YouTube URL, strip leading/trailing slashes, remove query parameters (? / &), and truncate to 11 characters (YouTube’s fixed ID length) before rendering.
2. Fix iframe embed URL — Only append ?si=${youtubeDescription} when description is present, avoiding malformed embed URLs with an empty si parameter.



Ref

[amp-youtube 標記異常](https://app.asana.com/1/614399484723017/project/1215753750830181/task/1213892930522001?focus=true)